### PR TITLE
validate paymentID supplied to create_integrated

### DIFF
--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -12,6 +12,7 @@
 #include <thread>
 #include <set>
 #include <sstream>
+#include <regex>
 
 #include <boost/bind.hpp>
 #include <boost/lexical_cast.hpp>
@@ -1362,6 +1363,13 @@ bool simple_wallet::create_integrated(const std::vector<std::string>& args/* = s
   }
 
   std::string paymentID = args[0];
+  std::regex hexChars("^[0-9a-f]+$");
+  if(paymentID.size() != 64 || !regex_match(paymentID, hexChars))
+  {
+    fail_msg_writer() << "Invalid payment ID";
+    return true;
+  }
+
   std::string address = m_wallet->getAddress();
   uint64_t prefix;
   CryptoNote::AccountPublicAddress addr;


### PR DESCRIPTION
Otherwise it will use an invalid paymentID to create an invalid integrated address if given