### PR TITLE
wallet: show info about each out on outputs command

### DIFF
--- a/include/IWalletLegacy.h
+++ b/include/IWalletLegacy.h
@@ -139,6 +139,7 @@ public:
   virtual size_t getTransferCount() = 0;
   virtual size_t getDepositCount() = 0;
   virtual size_t getNumUnlockedOutputs() = 0;
+  virtual std::vector<TransactionOutputInformation> getUnspentOutputs() = 0;
 
   virtual TransactionId findTransactionByTransferId(TransferId transferId) = 0;
   virtual void getAccountKeys(AccountKeys& keys) = 0;

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -1644,8 +1644,11 @@ bool simple_wallet::show_blockchain_height(const std::vector<std::string>& args)
 //----------------------------------------------------------------------------------------------------
 bool simple_wallet::show_num_unlocked_outputs(const std::vector<std::string>& args) {
   try {
-    size_t num_unlocked_outputs = m_wallet->getNumUnlockedOutputs();
-    success_msg_writer() << num_unlocked_outputs;
+    std::vector<TransactionOutputInformation> unlocked_outputs = m_wallet->getUnspentOutputs();
+    success_msg_writer() << "Count: " << unlocked_outputs.size();
+    for (const auto& out : unlocked_outputs) {
+      success_msg_writer() << "Key: " << out.transactionPublicKey << " amount: " << m_currency.formatAmount(out.amount);
+    }
   } catch (std::exception &e) {
     fail_msg_writer() << "failed to get outputs: " << e.what();
   }

--- a/src/WalletLegacy/WalletLegacy.cpp
+++ b/src/WalletLegacy/WalletLegacy.cpp
@@ -520,6 +520,12 @@ size_t WalletLegacy::getNumUnlockedOutputs() {
   return outputs.size();
 }
 
+std::vector<TransactionOutputInformation> WalletLegacy::getUnspentOutputs() {
+  std::vector<TransactionOutputInformation> outputs;
+  m_transferDetails->getOutputs(outputs, ITransfersContainer::IncludeKeyUnlocked);
+  return outputs;
+}
+
 TransactionId WalletLegacy::sendTransaction(Crypto::SecretKey& transactionSK,
                                             const WalletLegacyTransfer& transfer,
                                             uint64_t fee,

--- a/src/WalletLegacy/WalletLegacy.h
+++ b/src/WalletLegacy/WalletLegacy.h
@@ -68,6 +68,7 @@ public:
   virtual size_t getTransferCount() override;
   virtual size_t getDepositCount() override;
   virtual size_t getNumUnlockedOutputs() override;
+  virtual std::vector<TransactionOutputInformation> getUnspentOutputs() override;
   virtual bool isTrackingWallet();
   virtual TransactionId findTransactionByTransferId(TransferId transferId) override;
   virtual bool getTxProof(Crypto::Hash& txid, CryptoNote::AccountPublicAddress& address, Crypto::SecretKey& tx_key, std::string& sig_str) override;


### PR DESCRIPTION
Instead of just showing the number of available outputs, actually show the public key and associated amount for each output, along with the count