### PR TITLE
Add createAddressList to walletd

### DIFF
--- a/include/IWallet.h
+++ b/include/IWallet.h
@@ -139,6 +139,7 @@ public:
   virtual std::string createAddress() = 0;
   virtual std::string createAddress(const Crypto::SecretKey& spendSecretKey) = 0;
   virtual std::string createAddress(const Crypto::PublicKey& spendPublicKey) = 0;
+  virtual std::vector<std::string> createAddressList(const std::vector<Crypto::SecretKey>& spendSecretKeys, bool reset = true) = 0;
   virtual void deleteAddress(const std::string& address) = 0;
 
 

--- a/src/PaymentGate/PaymentServiceJsonRpcMessages.cpp
+++ b/src/PaymentGate/PaymentServiceJsonRpcMessages.cpp
@@ -16,7 +16,7 @@ void Save::Response::serialize(CryptoNote::ISerializer& /*serializer*/) {
 }
 
 void Reset::Request::serialize(CryptoNote::ISerializer& serializer) {
-  serializer(viewSecretKey, "secretViewKey");
+  serializer(viewSecretKey, "privateViewKey");
 }
 
 void Reset::Response::serialize(CryptoNote::ISerializer& serializer) {
@@ -26,7 +26,7 @@ void GetViewKey::Request::serialize(CryptoNote::ISerializer& serializer) {
 }
 
 void GetViewKey::Response::serialize(CryptoNote::ISerializer& serializer) {
-  serializer(viewSecretKey, "secretViewKey");
+  serializer(viewSecretKey, "privateViewKey");
 }
 
 void GetStatus::Request::serialize(CryptoNote::ISerializer& serializer) {

--- a/src/PaymentGate/PaymentServiceJsonRpcMessages.cpp
+++ b/src/PaymentGate/PaymentServiceJsonRpcMessages.cpp
@@ -60,6 +60,19 @@ void CreateAddress::Response::serialize(CryptoNote::ISerializer& serializer) {
   serializer(address, "address");
 }
 
+void CreateAddressList::Request::serialize(CryptoNote::ISerializer& serializer) 
+{
+  if (!serializer(spendSecretKeys, "spendSecretKeys")) 
+  {
+    throw RequestSerializationError();
+  }
+}
+
+void CreateAddressList::Response::serialize(CryptoNote::ISerializer& serializer) 
+{
+  serializer(addresses, "addresses");
+}
+
 void DeleteAddress::Request::serialize(CryptoNote::ISerializer& serializer) {
   if (!serializer(address, "address")) {
     throw RequestSerializationError();

--- a/src/PaymentGate/PaymentServiceJsonRpcMessages.h
+++ b/src/PaymentGate/PaymentServiceJsonRpcMessages.h
@@ -97,6 +97,22 @@ struct CreateAddress {
   };
 };
 
+struct CreateAddressList 
+{
+  struct Request 
+  {
+    std::vector<std::string> spendSecretKeys;
+    bool reset;
+    void serialize(CryptoNote::ISerializer& serializer);
+  };
+
+  struct Response 
+  {
+    std::vector<std::string> addresses;
+    void serialize(CryptoNote::ISerializer& serializer);
+  };
+};
+
 struct DeleteAddress {
   struct Request {
     std::string address;

--- a/src/PaymentGate/PaymentServiceJsonRpcServer.cpp
+++ b/src/PaymentGate/PaymentServiceJsonRpcServer.cpp
@@ -41,6 +41,7 @@ PaymentServiceJsonRpcServer::PaymentServiceJsonRpcServer(System::Dispatcher& sys
   handlers.emplace("createIntegrated", jsonHandler<CreateIntegrated::Request, CreateIntegrated::Response>(std::bind(&PaymentServiceJsonRpcServer::handleCreateIntegrated, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("reset", jsonHandler<Reset::Request, Reset::Response>(std::bind(&PaymentServiceJsonRpcServer::handleReset, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("createAddress", jsonHandler<CreateAddress::Request, CreateAddress::Response>(std::bind(&PaymentServiceJsonRpcServer::handleCreateAddress, this, std::placeholders::_1, std::placeholders::_2)));
+  handlers.emplace("createAddressList", jsonHandler<CreateAddressList::Request, CreateAddressList::Response>(std::bind(&PaymentServiceJsonRpcServer::handleCreateAddressList, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("deleteAddress", jsonHandler<DeleteAddress::Request, DeleteAddress::Response>(std::bind(&PaymentServiceJsonRpcServer::handleDeleteAddress, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("getSpendKeys", jsonHandler<GetSpendKeys::Request, GetSpendKeys::Response>(std::bind(&PaymentServiceJsonRpcServer::handleGetSpendKeys, this, std::placeholders::_1, std::placeholders::_2)));
   handlers.emplace("getBalance", jsonHandler<GetBalance::Request, GetBalance::Response>(std::bind(&PaymentServiceJsonRpcServer::handleGetBalance, this, std::placeholders::_1, std::placeholders::_2)));
@@ -117,6 +118,10 @@ std::error_code PaymentServiceJsonRpcServer::handleCreateAddress(const CreateAdd
   } else {
     return service.createTrackingAddress(request.spendPublicKey, response.address);
   }
+}
+
+std::error_code PaymentServiceJsonRpcServer::handleCreateAddressList(const CreateAddressList::Request& request, CreateAddressList::Response& response) {
+  return service.createAddressList(request.spendSecretKeys, request.reset, response.addresses);
 }
 
 std::error_code PaymentServiceJsonRpcServer::handleSave(const Save::Request& /*request*/, Save::Response& /*response*/) 

--- a/src/PaymentGate/PaymentServiceJsonRpcServer.h
+++ b/src/PaymentGate/PaymentServiceJsonRpcServer.h
@@ -64,6 +64,7 @@ private:
   std::error_code handleSave(const Save::Request& request, Save::Response& response);
   std::error_code handleCreateIntegrated(const CreateIntegrated::Request& request, CreateIntegrated::Response& response);
   std::error_code handleCreateAddress(const CreateAddress::Request& request, CreateAddress::Response& response);
+  std::error_code handleCreateAddressList(const CreateAddressList::Request& request, CreateAddressList::Response& response);
   std::error_code handleDeleteAddress(const DeleteAddress::Request& request, DeleteAddress::Response& response);
   std::error_code handleGetSpendKeys(const GetSpendKeys::Request& request, GetSpendKeys::Response& response);
   std::error_code handleGetBalance(const GetBalance::Request& request, GetBalance::Response& response);

--- a/src/PaymentGate/WalletService.cpp
+++ b/src/PaymentGate/WalletService.cpp
@@ -607,22 +607,61 @@ std::error_code WalletService::createAddress(const std::string& spendSecretKeyTe
   return std::error_code();
 }
 
-std::error_code WalletService::createAddress(std::string& address) {
-  try {
+std::error_code WalletService::createAddress(std::string& address) 
+{
+  try 
+  {
     System::EventLock lk(readyEvent);
-
     logger(Logging::DEBUGGING) << "Creating address";
-	
-	saveWallet();
-
+	  saveWallet();
     address = wallet.createAddress();
-  } catch (std::system_error& x) {
+  } 
+  catch (std::system_error& x) 
+  {
     logger(Logging::WARNING) << "Error while creating address: " << x.what();
     return x.code();
   }
 
   logger(Logging::DEBUGGING) << "Created address " << address;
+  return std::error_code();
+}
 
+std::error_code WalletService::createAddressList(const std::vector<std::string>& spendSecretKeysText, bool reset, std::vector<std::string>& addresses) 
+{
+  try 
+  {
+    System::EventLock lk(readyEvent);
+    logger(Logging::DEBUGGING) << "Creating " << spendSecretKeysText.size() << " addresses...";
+    std::vector<Crypto::SecretKey> secretKeys;
+    std::unordered_set<std::string> unique;
+    secretKeys.reserve(spendSecretKeysText.size());
+    unique.reserve(spendSecretKeysText.size());
+    for (auto& keyText : spendSecretKeysText) 
+    {
+      auto insertResult = unique.insert(keyText);
+      if (!insertResult.second) 
+      {
+        logger(Logging::WARNING, Logging::BRIGHT_YELLOW) << "Not unique key";
+        return make_error_code(CryptoNote::error::WalletServiceErrorCode::DUPLICATE_KEY);
+      }
+
+      Crypto::SecretKey key;
+      if (!Common::podFromHex(keyText, key)) 
+      {
+        logger(Logging::WARNING, Logging::BRIGHT_YELLOW) << "Wrong key format: " << keyText;
+        return make_error_code(CryptoNote::error::WalletServiceErrorCode::WRONG_KEY_FORMAT);
+      }
+      secretKeys.push_back(std::move(key));
+    }
+    addresses = wallet.createAddressList(secretKeys, reset);
+  } 
+  catch (std::system_error& x) 
+  {
+    logger(Logging::WARNING, Logging::BRIGHT_YELLOW) << "Error while creating addresses: " << x.what();
+    return x.code();
+  }
+
+  logger(Logging::DEBUGGING) << "Created " << addresses.size() << " addresses";
   return std::error_code();
 }
 

--- a/src/PaymentGate/WalletService.h
+++ b/src/PaymentGate/WalletService.h
@@ -50,6 +50,7 @@ public:
   std::error_code replaceWithNewWallet(const std::string& viewSecretKey);
   std::error_code createAddress(const std::string& spendSecretKeyText, std::string& address);
   std::error_code createAddress(std::string& address);
+  std::error_code createAddressList(const std::vector<std::string>& spendSecretKeysText, bool reset, std::vector<std::string>& addresses);  
   std::error_code createTrackingAddress(const std::string& spendPublicKeyText, std::string& address);
   std::error_code deleteAddress(const std::string& address);
   std::error_code getSpendkeys(const std::string& address, std::string& publicSpendKeyText, std::string& secretSpendKeyText);

--- a/src/PaymentGate/WalletServiceErrorCategory.h
+++ b/src/PaymentGate/WalletServiceErrorCategory.h
@@ -16,7 +16,9 @@ enum class WalletServiceErrorCode {
   WRONG_KEY_FORMAT = 1,
   WRONG_PAYMENT_ID_FORMAT,
   WRONG_HASH_FORMAT,
-  OBJECT_NOT_FOUND
+  OBJECT_NOT_FOUND,
+  DUPLICATE_KEY,
+  KEYS_NOT_DETERMINISTIC
 };
 
 // custom category:
@@ -40,6 +42,8 @@ public:
       case WalletServiceErrorCode::WRONG_PAYMENT_ID_FORMAT: return "Wrong payment id format";
       case WalletServiceErrorCode::WRONG_HASH_FORMAT: return "Wrong block id format";
       case WalletServiceErrorCode::OBJECT_NOT_FOUND: return "Requested object not found";
+      case WalletServiceErrorCode::DUPLICATE_KEY: return "Duplicate key";
+      case WalletServiceErrorCode::KEYS_NOT_DETERMINISTIC: return "Keys are non-deterministic";
       default: return "Unknown error";
     }
   }

--- a/src/Wallet/WalletGreen.h
+++ b/src/Wallet/WalletGreen.h
@@ -46,6 +46,8 @@ public:
   virtual std::string createAddress() override;
   virtual std::string createAddress(const Crypto::SecretKey& spendSecretKey) override;
   virtual std::string createAddress(const Crypto::PublicKey& spendPublicKey) override;
+  virtual std::vector<std::string> createAddressList(const std::vector<Crypto::SecretKey>& spendSecretKeys, bool reset = true) override;
+
   virtual void deleteAddress(const std::string& address) override;
 
   virtual uint64_t getActualBalance() const override;
@@ -82,6 +84,12 @@ public:
   virtual IFusionManager::EstimateResult estimate(uint64_t threshold, const std::vector<std::string>& sourceAddresses = {}) const override;
 
 protected:
+  struct NewAddressData {
+    Crypto::PublicKey spendPublicKey;
+    Crypto::SecretKey spendSecretKey;
+    uint64_t creationTimestamp;
+  };
+
   void throwIfNotInitialized() const;
   void throwIfStopped() const;
   void throwIfTrackingMode() const;
@@ -89,6 +97,8 @@ protected:
   void clearCaches();
   void initWithKeys(const Crypto::PublicKey& viewPublicKey, const Crypto::SecretKey& viewSecretKey, const std::string& password);
   std::string doCreateAddress(const Crypto::PublicKey& spendPublicKey, const Crypto::SecretKey& spendSecretKey, uint64_t creationTimestamp);
+  std::vector<std::string> doCreateAddressList(const std::vector<NewAddressData>& addressDataList);
+
 
   struct InputInfo {
     TransactionTypes::InputKeyInfo keyInfo;


### PR DESCRIPTION
One of the issues with the service wallet is that if you need to restore additional wallets with keys, there is mechanism to import the privateSpendKeys of more than one wallet at a time. With createAddressList you can provide an array of privateSpendKeys in the params and all corresponding wallets will be created in the container.