### PR TITLE
Check coinbase transaction signature count

### DIFF
--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -983,17 +983,25 @@ difficulty_type Blockchain::get_next_difficulty_for_alternative_chain(const std:
 
 bool Blockchain::prevalidate_miner_transaction(const Block& b, uint32_t height) {
 
-  if (!(b.baseTransaction.inputs.size() == 1)) {
-    logger(ERROR, BRIGHT_RED)
-      << "coinbase transaction in the block has no inputs";
-
+  /* The coinbase transaction should only have outputs */
+  if (!(b.baseTransaction.inputs.size() == 1)) 
+  {
+    logger(ERROR, BRIGHT_RED) << "coinbase transaction in the block has no inputs";
     return false;
   }
 
-  if (!(b.baseTransaction.inputs[0].type() == typeid(BaseInput))) {
-    logger(ERROR, BRIGHT_RED)
-      << "<< Blockchain.cpp << " << "coinbase transaction in the block has the wrong type";
+  /* The base transaction should not have more than one signature 
+     This is different to other coins which have 0 signatures for the coinbase transaction
+     because they do not do multisignature transactions as we do for our deposits */
+  if (b.baseTransaction.signatures.size() > 1) 
+  {
+    logger(ERROR, BRIGHT_RED) << "<< Blockchain.cpp << coinbase transaction in the block shouldn't have more than 1 signature. Signature count: " << b.baseTransaction.signatures.size();
+    return false;
+  }
 
+  if (!(b.baseTransaction.inputs[0].type() == typeid(BaseInput))) 
+  {
+    logger(ERROR, BRIGHT_RED) << "<< Blockchain.cpp << " << "coinbase transaction in the block has the wrong type";
     return false;
   }
 


### PR DESCRIPTION
This change ensures that the signature count for the coinbase transaction does not exceed 1 to prevent a blockchain bloat exploit, where the coinbase transaction could be added with additional signatures. Over time this could result in a significant increase in the size of the blockchain. Analysis of the chain so far does not show any use of the exploit.