### PR TITLE
Silent gtest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,14 @@ set(CMAKE_SKIP_INSTALL_RULES ON)
 set(CMAKE_SKIP_PACKAGE_ALL_DEPENDENCY ON)
 set(CMAKE_SUPPRESS_REGENERATION ON)
 enable_testing()
+
+if(DO_TESTS)
+  message(STATUS "BUILD TESTS: enabled")
+  enable_testing()
+else()
+  message(STATUS "BUILD TESTS: disabled")
+endif()
+
 # copy CTestCustom.cmake to build dir to disable long running tests in 'make test'
 configure_file(${CMAKE_SOURCE_DIR}/CTestCustom.cmake ${CMAKE_BINARY_DIR})
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -3,12 +3,19 @@ set(UPNPC_BUILD_SHARED OFF CACHE BOOL "Build shared library")
 set(UPNPC_BUILD_TESTS OFF CACHE BOOL "Build test executables")
 
 add_subdirectory(miniupnpc)
-add_subdirectory(gtest)
 
-set_property(TARGET upnpc-static gtest gtest_main PROPERTY FOLDER "external")
+if (DO_TESTS)
+  add_subdirectory(gtest)
+endif()
+
+set_property(TARGET upnpc-static PROPERTY FOLDER "external")
 
 if(MSVC)
   set_property(TARGET upnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -wd4244 -wd4267")
 elseif(NOT MSVC)
   set_property(TARGET upnpc-static APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-undef -Wno-unused-result -Wno-unused-value")
+endif()
+
+if(DO_TESTS)
+  set_property(TARGET gtest gtest_main PROPERTY FOLDER "external")
 endif()


### PR DESCRIPTION
When compiling, gtest will spam text like this;
```bash
/home/lithy/lithe-dev/external/gtest/include/gtest/internal/gtest-port.h:310:5: warning: "_MSC_VER" is not defined, evaluates to 0 [-Wundef]
 #if _MSC_VER >= 1500
     ^~~~~~~~
/home/lithy/lithe-dev/external/gtest/include/gtest/internal/gtest-port.h:398:5: warning: "GTEST_OS_WINDOWS" is not defined, evaluates to 0 [-Wundef]
 #if GTEST_OS_WINDOWS
     ^~~~~~~~~~~~~~~~
In file included from /home/lithy/lithe-dev/external/gtest/include/gtest/internal/gtest-internal.h:39:0,
                 from /home/lithy/lithe-dev/external/gtest/include/gtest/gtest.h:58,
                 from /home/lithy/lithe-dev/external/gtest/src/gtest-all.cc:39:
/home/lithy/lithe-dev/external/gtest/include/gtest/internal/gtest-port.h:422:5: warning: "GTEST_OS_LINUX_ANDROID" is not defined, evaluates to 0 [-Wundef]
 #if GTEST_OS_LINUX_ANDROID
```
and so on...

This PR will silent those warnings/errors if you are not building with tests and the cmake logged output will include this line `- BUILD TESTS: disabled` when you run `cmake ..` from your `/build/` folder.