### PR TITLE
Chacha8 cleanup

### DIFF
--- a/src/CryptoNoteCore/CryptoNoteSerialization.cpp
+++ b/src/CryptoNoteCore/CryptoNoteSerialization.cpp
@@ -151,8 +151,8 @@ bool serialize(KeyImage& keyImage, Common::StringView name, CryptoNote::ISeriali
   return serializePod(keyImage, name, serializer);
 }
 
-bool serialize(chacha_iv& chacha, Common::StringView name, CryptoNote::ISerializer& serializer) {
-  return serializePod(chacha, name, serializer);
+bool serialize(chacha8_iv& chacha8, Common::StringView name, CryptoNote::ISerializer& serializer) {
+  return serializePod(chacha8, name, serializer);
 }
 
 bool serialize(Signature& sig, Common::StringView name, CryptoNote::ISerializer& serializer) {

--- a/src/CryptoNoteCore/CryptoNoteSerialization.h
+++ b/src/CryptoNoteCore/CryptoNoteSerialization.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "CryptoNoteBasic.h"
-#include "crypto/chacha.h"
+#include "crypto/chacha8.h"
 #include "Serialization/ISerializer.h"
 #include "crypto/crypto.h"
 
@@ -16,7 +16,7 @@ namespace Crypto {
 bool serialize(PublicKey& pubKey, Common::StringView name, CryptoNote::ISerializer& serializer);
 bool serialize(SecretKey& secKey, Common::StringView name, CryptoNote::ISerializer& serializer);
 bool serialize(Hash& h, Common::StringView name, CryptoNote::ISerializer& serializer);
-bool serialize(chacha_iv& chacha, Common::StringView name, CryptoNote::ISerializer& serializer);
+bool serialize(chacha8_iv& chacha8, Common::StringView name, CryptoNote::ISerializer& serializer);
 bool serialize(KeyImage& keyImage, Common::StringView name, CryptoNote::ISerializer& serializer);
 bool serialize(Signature& sig, Common::StringView name, CryptoNote::ISerializer& serializer);
 bool serialize(EllipticCurveScalar& ecScalar, Common::StringView name, CryptoNote::ISerializer& serializer);

--- a/src/CryptoNoteCore/TransactionExtra.cpp
+++ b/src/CryptoNoteCore/TransactionExtra.cpp
@@ -327,7 +327,7 @@ bool tx_extra_message::encrypt(size_t index, const std::string &message, const A
     key_data.magic2 = 0;
     Hash h = cn_fast_hash(&key_data, sizeof(message_key_data));
     uint64_t nonce = SWAP64LE(index);
-    chacha(10, buf.get(), mlen, reinterpret_cast<uint8_t *>(&h), reinterpret_cast<uint8_t *>(&nonce), buf.get());
+    chacha8(10, buf.get(), mlen, reinterpret_cast<uint8_t *>(&h), reinterpret_cast<uint8_t *>(&nonce), buf.get());
   }
   data.assign(buf.get(), mlen);
   return true;
@@ -351,7 +351,7 @@ bool tx_extra_message::decrypt(size_t index, const Crypto::PublicKey &txkey, con
     key_data.magic2 = 0;
     Hash h = cn_fast_hash(&key_data, sizeof(message_key_data));
     uint64_t nonce = SWAP64LE(index);
-    chacha(10, data.data(), mlen, reinterpret_cast<uint8_t *>(&h), reinterpret_cast<uint8_t *>(&nonce), ptr.get());
+    chacha8(10, data.data(), mlen, reinterpret_cast<uint8_t *>(&h), reinterpret_cast<uint8_t *>(&nonce), ptr.get());
     buf = ptr.get();
   } else {
     buf = data.data();

--- a/src/Wallet/LegacyKeysImporter.cpp
+++ b/src/Wallet/LegacyKeysImporter.cpp
@@ -26,7 +26,7 @@ using namespace Crypto;
 namespace {
 
 struct keys_file_data {
-  chacha_iv iv;
+  chacha8_iv iv;
   std::string account_data;
 
   void serialize(CryptoNote::ISerializer& s) {
@@ -53,7 +53,7 @@ void loadKeysFromFile(const std::string& filename, const std::string& password, 
     throw std::system_error(make_error_code(CryptoNote::error::INTERNAL_WALLET_ERROR), "failed to deserialize \"" + filename + '\"');
   }
 
-  chacha_key key;
+  chacha8_key key;
   cn_context cn_context;
   generate_chacha8_key(cn_context, password, key);
   std::string account_data;

--- a/src/Wallet/WalletSerialization.cpp
+++ b/src/Wallet/WalletSerialization.cpp
@@ -333,7 +333,7 @@ CryptoContext WalletSerializer::generateCryptoContext(const std::string& passwor
   Crypto::cn_context c;
   Crypto::generate_chacha8_key(c, password, context.key);
 
-  context.iv = Crypto::rand<Crypto::chacha_iv>();
+  context.iv = Crypto::rand<Crypto::chacha8_iv>();
 
   return context;
 }
@@ -345,9 +345,9 @@ void WalletSerializer::saveVersion(Common::IOutputStream& destination) {
   s(version, "version");
 }
 
-void WalletSerializer::saveIv(Common::IOutputStream& destination, Crypto::chacha_iv& iv) {
+void WalletSerializer::saveIv(Common::IOutputStream& destination, Crypto::chacha8_iv& iv) {
   BinaryOutputStreamSerializer s(destination);
-  s.binary(reinterpret_cast<void *>(&iv.data), sizeof(iv.data), "chacha_iv");
+  s.binary(reinterpret_cast<void *>(&iv.data), sizeof(iv.data), "chacha8_iv");
 }
 
 void WalletSerializer::saveKeys(Common::IOutputStream& destination, CryptoContext& cryptoContext) {
@@ -613,13 +613,13 @@ uint32_t WalletSerializer::loadVersion(Common::IInputStream& source) {
   return version;
 }
 
-void WalletSerializer::loadIv(Common::IInputStream& source, Crypto::chacha_iv& iv) {
+void WalletSerializer::loadIv(Common::IInputStream& source, Crypto::chacha8_iv& iv) {
   CryptoNote::BinaryInputStreamSerializer s(source);
 
-  s.binary(static_cast<void *>(&iv.data), sizeof(iv.data), "chacha_iv");
+  s.binary(static_cast<void *>(&iv.data), sizeof(iv.data), "chacha8_iv");
 }
 
-void WalletSerializer::generateKey(const std::string& password, Crypto::chacha_key& key) {
+void WalletSerializer::generateKey(const std::string& password, Crypto::chacha8_key& key) {
   Crypto::cn_context context;
   Crypto::generate_chacha8_key(context, password, key);
 }

--- a/src/Wallet/WalletSerialization.h
+++ b/src/Wallet/WalletSerialization.h
@@ -13,13 +13,13 @@
 #include "Transfers/TransfersSynchronizer.h"
 #include "Serialization/BinaryInputStreamSerializer.h"
 
-#include "crypto/chacha.h"
+#include "crypto/chacha8.h"
 
 namespace CryptoNote {
 
 struct CryptoContext {
-  Crypto::chacha_key key;
-  Crypto::chacha_iv iv;
+  Crypto::chacha8_key key;
+  Crypto::chacha8_iv iv;
 
   void incIv();
 };
@@ -53,7 +53,7 @@ private:
   CryptoContext generateCryptoContext(const std::string& password);
 
   void saveVersion(Common::IOutputStream& destination);
-  void saveIv(Common::IOutputStream& destination, Crypto::chacha_iv& iv);
+  void saveIv(Common::IOutputStream& destination, Crypto::chacha8_iv& iv);
   void saveKeys(Common::IOutputStream& destination, CryptoContext& cryptoContext);
   void savePublicKey(Common::IOutputStream& destination, CryptoContext& cryptoContext);
   void saveSecretKey(Common::IOutputStream& destination, CryptoContext& cryptoContext);
@@ -67,8 +67,8 @@ private:
   void saveTransfers(Common::IOutputStream& destination, CryptoContext& cryptoContext);
 
   uint32_t loadVersion(Common::IInputStream& source);
-  void loadIv(Common::IInputStream& source, Crypto::chacha_iv& iv);
-  void generateKey(const std::string& password, Crypto::chacha_key& key);
+  void loadIv(Common::IInputStream& source, Crypto::chacha8_iv& iv);
+  void generateKey(const std::string& password, Crypto::chacha8_key& key);
   void loadKeys(Common::IInputStream& source, CryptoContext& cryptoContext);
   void loadPublicKey(Common::IInputStream& source, CryptoContext& cryptoContext);
   void loadSecretKey(Common::IInputStream& source, CryptoContext& cryptoContext);

--- a/src/WalletLegacy/WalletLegacySerializer.cpp
+++ b/src/WalletLegacy/WalletLegacySerializer.cpp
@@ -64,7 +64,7 @@ void WalletLegacySerializer::serialize(std::ostream& stream, const std::string& 
   std::string plain = plainArchive.str();
   std::string cipher;
 
-  Crypto::chacha_iv iv = encrypt(plain, password, cipher);
+  Crypto::chacha8_iv iv = encrypt(plain, password, cipher);
 
   uint32_t version = walletSerializationVersion;
   StdOutputStream output(stream);
@@ -91,14 +91,14 @@ void WalletLegacySerializer::saveKeys(CryptoNote::ISerializer& serializer) {
   keys.serialize(serializer, "keys");
 }
 
-Crypto::chacha_iv WalletLegacySerializer::encrypt(const std::string& plain, const std::string& password, std::string& cipher) {
-  Crypto::chacha_key key;
+Crypto::chacha8_iv WalletLegacySerializer::encrypt(const std::string& plain, const std::string& password, std::string& cipher) {
+  Crypto::chacha8_key key;
   Crypto::cn_context context;
   Crypto::generate_chacha8_key(context, password, key);
 
   cipher.resize(plain.size());
 
-  Crypto::chacha_iv iv = Crypto::rand<Crypto::chacha_iv>();
+  Crypto::chacha8_iv iv = Crypto::rand<Crypto::chacha8_iv>();
   Crypto::chacha8(plain.data(), plain.size(), key, iv, &cipher[0]);
 
   return iv;
@@ -114,7 +114,7 @@ void WalletLegacySerializer::deserialize(std::istream& stream, const std::string
   uint32_t version;
   serializerEncrypted(version, "version");
 
-  Crypto::chacha_iv iv;
+  Crypto::chacha8_iv iv;
   serializerEncrypted(iv, "iv");
 
   std::string cipher;
@@ -164,7 +164,7 @@ bool WalletLegacySerializer::deserialize(std::istream& stream, const std::string
     uint32_t version;
     serializerEncrypted(version, "version");
 
-    Crypto::chacha_iv iv;
+    Crypto::chacha8_iv iv;
     serializerEncrypted(iv, "iv");
 
     std::string cipher;
@@ -223,8 +223,8 @@ bool WalletLegacySerializer::deserialize(std::istream& stream, const std::string
 
 
 
-void WalletLegacySerializer::decrypt(const std::string& cipher, std::string& plain, Crypto::chacha_iv iv, const std::string& password) {
-  Crypto::chacha_key key;
+void WalletLegacySerializer::decrypt(const std::string& cipher, std::string& plain, Crypto::chacha8_iv iv, const std::string& password) {
+  Crypto::chacha8_key key;
   Crypto::cn_context context;
   Crypto::generate_chacha8_key(context, password, key);
 

--- a/src/WalletLegacy/WalletLegacySerializer.h
+++ b/src/WalletLegacy/WalletLegacySerializer.h
@@ -11,7 +11,7 @@
 #include <istream>
 
 #include "crypto/hash.h"
-#include "crypto/chacha.h"
+#include "crypto/chacha8.h"
 
 namespace CryptoNote {
 class AccountBase;
@@ -34,8 +34,8 @@ private:
   void saveKeys(CryptoNote::ISerializer& serializer);
   void loadKeys(CryptoNote::ISerializer& serializer);
 
-  Crypto::chacha_iv encrypt(const std::string& plain, const std::string& password, std::string& cipher);
-  void decrypt(const std::string& cipher, std::string& plain, Crypto::chacha_iv iv, const std::string& password);
+  Crypto::chacha8_iv encrypt(const std::string& plain, const std::string& password, std::string& cipher);
+  void decrypt(const std::string& cipher, std::string& plain, Crypto::chacha8_iv iv, const std::string& password);
 
   CryptoNote::AccountBase& account;
   WalletUserTransactionsCache& transactionsCache;

--- a/src/crypto/chacha8.c
+++ b/src/crypto/chacha8.c
@@ -37,7 +37,7 @@ Public domain.
 
 static const char sigma[] = "expand 32-byte k";
 
-void chacha8(const void* data, size_t length, const uint8_t* key, const uint8_t* iv, char* cipher) {
+void chacha8(size_t doubleRounds, const void* data, size_t length, const uint8_t* key, const uint8_t* iv, char* cipher) {
   uint32_t x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15;
   uint32_t j0, j1, j2, j3, j4, j5, j6, j7, j8, j9, j10, j11, j12, j13, j14, j15;
   char* ctarget = 0;
@@ -86,7 +86,7 @@ void chacha8(const void* data, size_t length, const uint8_t* key, const uint8_t*
     x13 = j13;
     x14 = j14;
     x15 = j15;
-    for (i = 8;i > 0;i -= 2) {
+    for (i = 0; i < doubleRounds; i++) {
       QUARTERROUND( x0, x4, x8,x12)
       QUARTERROUND( x1, x5, x9,x13)
       QUARTERROUND( x2, x6,x10,x14)

--- a/src/crypto/chacha8.h
+++ b/src/crypto/chacha8.h
@@ -1,3 +1,9 @@
+// Copyright (c) 2011-2017 The Cryptonote developers
+// Copyright (c) 2017-2018 The Circle Foundation & Conceal Devs
+// Copyright (c) 2018-2019 Conceal Network & Conceal Devs
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #pragma once
 
 #include <stdint.h>
@@ -15,7 +21,7 @@
 namespace Crypto {
   extern "C" {
 #endif
-    void chacha8(const void* data, size_t length, const uint8_t* key, const uint8_t* iv, char* cipher);
+    void chacha8(size_t doubleRounds, const void* data, size_t length, const uint8_t* key, const uint8_t* iv, char* cipher);
 #if defined(__cplusplus)
   }
 
@@ -38,7 +44,7 @@ namespace Crypto {
   static_assert(sizeof(chacha8_key) == CHACHA8_KEY_SIZE && sizeof(chacha8_iv) == CHACHA8_IV_SIZE, "Invalid structure size");
 
   inline void chacha8(const void* data, size_t length, const chacha8_key& key, const chacha8_iv& iv, char* cipher) {
-    chacha8(data, length, reinterpret_cast<const uint8_t*>(&key), reinterpret_cast<const uint8_t*>(&iv), cipher);
+    chacha8(4, data, length, reinterpret_cast<const uint8_t*>(&key), reinterpret_cast<const uint8_t*>(&iv), cipher);
   }
 
   inline void generate_chacha8_key(Crypto::cn_context &context, const std::string& password, chacha8_key& key) {

--- a/tests/UnitTests/Chacha8.cpp
+++ b/tests/UnitTests/Chacha8.cpp
@@ -7,7 +7,7 @@
 
 #include "gtest/gtest.h"
 
-#include "crypto/chacha.h"
+#include "crypto/chacha8.h"
 
 namespace
 {
@@ -65,10 +65,10 @@ namespace
     std::string buf;
     buf.resize(test->text_length);
 
-    Crypto::chacha8(test->plain_text, test->text_length, *reinterpret_cast<const Crypto::chacha_key*>(test->key), *reinterpret_cast<const Crypto::chacha_iv*>(test->iv), &buf[0]);
+    Crypto::chacha8(test->plain_text, test->text_length, *reinterpret_cast<const Crypto::chacha8_key*>(test->key), *reinterpret_cast<const Crypto::chacha8_iv*>(test->iv), &buf[0]);
     ASSERT_EQ(buf, std::string(reinterpret_cast<const char*>(test->cipher_text), test->text_length));
 
-    Crypto::chacha8(test->cipher_text, test->text_length, *reinterpret_cast<const Crypto::chacha_key*>(test->key), *reinterpret_cast<const Crypto::chacha_iv*>(test->iv), &buf[0]);
+    Crypto::chacha8(test->cipher_text, test->text_length, *reinterpret_cast<const Crypto::chacha8_key*>(test->key), *reinterpret_cast<const Crypto::chacha8_iv*>(test->iv), &buf[0]);
     ASSERT_EQ(buf, std::string(reinterpret_cast<const char*>(test->plain_text), test->text_length));
   }
 }


### PR DESCRIPTION
I noticed there are 2 instances of `chacha8` within Conceal. If you take a look within `conceal-core/src/crypto`, you can see we have `chacha.c/h` and `chacha8.c/h` with minor differences.

I've fixed it up and and deleted the other files so we dont get confused between the two. You can see what i've done here; https://github.com/LithyRiolu/lithe/commit/f53c9ba814eac3fc09b99bc778342eba1d8c5513 and it passes the AppVeyor CI for windows.

I've tested it also by creating new wallets, loading them and mining with them (to verify incoming txs) and everything looks legit.