### PR TITLE
Logging

### DIFF
--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -2,8 +2,6 @@
 // Copyright (c) 2016-2018, The Karbo developers
 // Copyright (c) 2017-2018 The Circle Foundation & Conceal Devs
 // Copyright (c) 2018-2019 Conceal Network & Conceal Devs
-// Copyright (c) 2019-2020 The Lithe Project Development Team
-//
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -2,6 +2,8 @@
 // Copyright (c) 2016-2018, The Karbo developers
 // Copyright (c) 2017-2018 The Circle Foundation & Conceal Devs
 // Copyright (c) 2018-2019 Conceal Network & Conceal Devs
+// Copyright (c) 2019-2020 The Lithe Project Development Team
+//
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -244,17 +244,17 @@ int main(int argc, char* argv[])
     // configure logging
     logManager.configure(buildLoggerConfiguration(cfgLogLevel, cfgLogFile));
 
-    logger(INFO) << "<< Daemon.cpp << " << CryptoNote::CRYPTONOTE_NAME << " v" << PROJECT_VERSION_LONG;
+    logger(INFO, BRIGHT_YELLOW) << "<< Daemon.cpp << " << CryptoNote::CRYPTONOTE_NAME << " v" << PROJECT_VERSION_LONG;
 
     if (command_line_preprocessor(vm, logger)) {
       return 0;
     }
 
-    logger(INFO) << "<< Daemon.cpp << " "Module folder: " << argv[0];
+    logger(INFO, GREEN) << "<< Daemon.cpp << " "Module folder: " << argv[0];
 
     bool testnet_mode = command_line::get_arg(vm, arg_testnet_on);
     if (testnet_mode) {
-      logger(INFO) << "<< Daemon.cpp << " "Starting in testnet mode!";
+      logger(INFO, BRIGHT_YELLOW) << "<< Daemon.cpp << " "Starting in testnet mode!";
     }
 
     //create objects and link them
@@ -302,29 +302,29 @@ int main(int argc, char* argv[])
     DaemonCommandsHandler dch(ccore, p2psrv, logManager);
 
     // initialize objects
-    logger(INFO) << "<< Daemon.cpp << " "Initializing p2p server...";
+    logger(INFO, GREEN) << "<< Daemon.cpp << " "Initializing p2p server...";
     if (!p2psrv.init(netNodeConfig)) {
       logger(ERROR, BRIGHT_RED) << "Failed to initialize p2p server.";
       return 1;
     }
 
-    logger(INFO) << "<< Daemon.cpp << " "P2p server initialized OK";
+    logger(INFO, BRIGHT_GREEN) << "<< Daemon.cpp << " "P2p server initialized OK";
 
     // initialize core here
-    logger(INFO) << "<< Daemon.cpp << " "Initializing core...";
+    logger(INFO, GREEN) << "<< Daemon.cpp << " "Initializing core...";
     if (!ccore.init(coreConfig, minerConfig, true)) {
       logger(ERROR, BRIGHT_RED) << "Failed to initialize core";
       return 1;
     }
 
-    logger(INFO) << "<< Daemon.cpp << " "Core initialized OK";
+    logger(INFO, BRIGHT_GREEN) << "<< Daemon.cpp << " "Core initialized OK";
 
     // start components
     if (!command_line::has_arg(vm, arg_console)) {
       dch.start_handling();
     }
 
-    logger(INFO) << "<< Daemon.cpp << " << "Starting core rpc server on address " << rpcConfig.getBindAddress();
+    logger(INFO, GREEN) << "<< Daemon.cpp << " << "Starting core rpc server on address: " << rpcConfig.getBindAddress();
   
     /* Set address for remote node fee */
   	if (command_line::has_arg(vm, arg_set_fee_address)) {
@@ -352,27 +352,27 @@ int main(int argc, char* argv[])
     }
  
     rpcServer.start(rpcConfig.bindIp, rpcConfig.bindPort);
-    logger(INFO) << "<< Daemon.cpp << " "Core rpc server started ok";
+    logger(INFO, BRIGHT_GREEN) << "<< Daemon.cpp << " "Core rpc server started ok";
 
     Tools::SignalHandler::install([&dch, &p2psrv] {
       dch.stop_handling();
       p2psrv.sendStopSignal();
     });
 
-    logger(INFO) << "<< Daemon.cpp << " "Starting p2p net loop...";
+    logger(INFO, GREEN) << "<< Daemon.cpp << " "Starting p2p net loop...";
     p2psrv.run();
-    logger(INFO) << "<< Daemon.cpp << " "p2p net loop stopped";
+    logger(INFO, YELLOW) << "<< Daemon.cpp << " "p2p net loop stopped";
 
     dch.stop_handling();
 
     //stop components
-    logger(INFO) << "<< Daemon.cpp << " "Stopping core rpc server...";
+    logger(INFO, YELLOW) << "<< Daemon.cpp << " "Stopping core rpc server...";
     rpcServer.stop();
 
     //deinitialize components
-    logger(INFO) << "<< Daemon.cpp << " "Deinitializing core...";
+    logger(INFO, YELLOW) << "<< Daemon.cpp << " "Deinitializing core...";
     ccore.deinit();
-    logger(INFO) << "<< Daemon.cpp << " "Deinitializing p2p...";
+    logger(INFO, YELLOW) << "<< Daemon.cpp << " "Deinitializing p2p...";
     p2psrv.deinit();
 
     ccore.set_cryptonote_protocol(NULL);
@@ -383,7 +383,7 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-  logger(INFO) << "<< Daemon.cpp << " "Node stopped.";
+  logger(INFO, YELLOW) << "<< Daemon.cpp << " "Node stopped.";
   return 0;
 }
 

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -214,7 +214,7 @@ namespace CryptoNote
     s(version, "version");
 
     if (version != 1) {
-      return;
+      throw std::runtime_error("Unsupported version");
     }
 
     s(m_peerlist, "peerlist");
@@ -286,7 +286,8 @@ namespace CryptoNote
           CryptoNote::serialize(*this, a);
           loaded = true;
         }
-      } catch (std::exception&) {
+      } catch (const std::exception& e) {
+        logger(ERROR, BRIGHT_RED) << "<< NetNode.cpp << Failed to load config from file '" << state_file_path << "': " << e.what();
       }
 
       if (!loaded) {
@@ -304,7 +305,7 @@ namespace CryptoNote
 
       m_first_connection_maker_call = true;
     } catch (const std::exception& e) {
-      logger(ERROR) << "init_config failed: " << e.what();
+      logger(ERROR, BRIGHT_RED) << "<< NetNode.cpp << init_config failed: " << e.what();
       return false;
     }
     return true;
@@ -329,6 +330,7 @@ namespace CryptoNote
   bool NodeServer::make_default_config()
   {
     m_config.m_peer_id  = Crypto::rand<uint64_t>();
+    logger(INFO, YELLOW) << "<< NetNode.cpp << Generated new peer ID: " << m_config.m_peer_id;
     return true;
   }
 

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) 2011-2017 The Cryptonote developers
 // Copyright (c) 2017-2018 The Circle Foundation & Conceal Devs
 // Copyright (c) 2018-2019 Conceal Network & Conceal Devs
+// Copyright (c) 2019-2020 The Lithe Project Development Team
+//
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -61,7 +63,7 @@ size_t get_random_index_with_fixed_probability(size_t max_index) {
 
 void addPortMapping(Logging::LoggerRef& logger, uint32_t port) {
   // Add UPnP port mapping
-  logger(INFO) <<  "Attempting to add IGD port mapping.";
+  logger(INFO, BRIGHT_YELLOW) <<  "<< NetNode.cpp << Attempting to add IGD port mapping.";
   int result;
   UPNPDev* deviceList = upnpDiscover(1000, NULL, NULL, 0, 0, &result);
   UPNPUrls urls;
@@ -75,21 +77,21 @@ void addPortMapping(Logging::LoggerRef& logger, uint32_t port) {
       portString << port;
       if (UPNP_AddPortMapping(urls.controlURL, igdData.first.servicetype, portString.str().c_str(),
         portString.str().c_str(), lanAddress, CryptoNote::CRYPTONOTE_NAME, "TCP", 0, "0") != 0) {
-        logger(ERROR) << "UPNP_AddPortMapping failed.";
+        logger(ERROR) << "<< NetNode.cpp << UPNP_AddPortMapping failed.";
       } else {
-        logger(INFO, BRIGHT_GREEN) << "Added IGD port mapping.";
+        logger(INFO, BRIGHT_GREEN) << "<< NetNode.cpp << Added IGD port mapping.";
       }
     } else if (result == 2) {
-      logger(INFO) <<  "IGD was found but reported as not connected.";
+      logger(INFO, YELLOW) <<  "<< NetNode.cpp << IGD was found but reported as not connected.";
     } else if (result == 3) {
-      logger(INFO) <<  "UPnP device was found but not recoginzed as IGD.";
+      logger(INFO, YELLOW) <<  "<< NetNode.cpp << UPnP device was found but not recoginzed as IGD.";
     } else {
-      logger(ERROR) << "UPNP_GetValidIGD returned an unknown result code.";
+      logger(ERROR) << "<< NetNode.cpp << UPNP_GetValidIGD returned an unknown result code.";
     }
 
     FreeUPNPUrls(&urls);
   } else {
-    logger(INFO) <<  "No IGD was found.";
+    logger(INFO, YELLOW) <<  "<< NetNode.cpp << No IGD was found.";
   }
 }
 
@@ -468,7 +470,7 @@ namespace CryptoNote
     // m_net_server.get_config_object().m_invoke_timeout = CryptoNote::P2P_DEFAULT_INVOKE_TIMEOUT;
 
     //try to bind
-    logger(INFO) <<  "Binding on " << m_bind_ip << ":" << m_port;
+    logger(INFO, BRIGHT_YELLOW) <<  "<< NetNode.cpp << Binding on: " << m_bind_ip << ":" << m_port;
     m_listeningPort = Common::fromString<uint16_t>(m_port);
 
     m_listener = System::TcpListener(m_dispatcher, System::Ipv4Address(m_bind_ip), static_cast<uint16_t>(m_listeningPort));
@@ -492,7 +494,7 @@ namespace CryptoNote
   //-----------------------------------------------------------------------------------
 
   bool NodeServer::run() {
-    logger(INFO) <<  "Starting node_server";
+    logger(INFO, BRIGHT_GREEN) <<  "<< NetNode.cpp << Starting node_server";
 
     m_workingContextGroup.spawn(std::bind(&NodeServer::acceptLoop, this));
     m_workingContextGroup.spawn(std::bind(&NodeServer::onIdle, this));

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) 2011-2017 The Cryptonote developers
 // Copyright (c) 2017-2018 The Circle Foundation & Conceal Devs
 // Copyright (c) 2018-2019 Conceal Network & Conceal Devs
-// Copyright (c) 2019-2020 The Lithe Project Development Team
-//
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -106,6 +106,7 @@ RpcServer::RpcServer(System::Dispatcher& dispatcher, Logging::ILogger& log, core
 }
 
 void RpcServer::processRequest(const HttpRequest& request, HttpResponse& response) {
+  logger(TRACE) << "<< RpcServer.cpp << RPC request came: \n" << request << std::endl;
   auto url = request.getUrl();
 
   auto it = s_handlers.find(url);
@@ -693,6 +694,9 @@ bool RpcServer::on_send_raw_tx(const COMMAND_RPC_SEND_RAW_TX::request& req, COMM
     res.status = "Failed";
     return true;
   }
+
+  Crypto::Hash transactionHash = Crypto::cn_fast_hash(tx_blob.data(), tx_blob.size());
+  logger(DEBUGGING) << "<< rpcserver.cpp << transaction " << transactionHash << " came in on_send_raw_tx";
 
   tx_verification_context tvc = boost::value_initialized<tx_verification_context>();
   if (!m_core.handle_incoming_tx(tx_blob, tvc, false))
@@ -1304,6 +1308,5 @@ bool RpcServer::on_get_block_header_by_height(const COMMAND_RPC_GET_BLOCK_HEADER
   res.status = CORE_RPC_STATUS_OK;
   return true;
 }
-
 
 }

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) 2011-2017 The Cryptonote developers
 // Copyright (c) 2017-2018 The Circle Foundation & Conceal Devs
 // Copyright (c) 2018-2019 Conceal Network & Conceal Devs
+// Copyright (c) 2019-2020 The Lithe Project Development Team
+//
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -107,6 +109,7 @@ RpcServer::RpcServer(System::Dispatcher& dispatcher, Logging::ILogger& log, core
 
 void RpcServer::processRequest(const HttpRequest& request, HttpResponse& response) {
   logger(TRACE) << "<< RpcServer.cpp << RPC request came: \n" << request << std::endl;
+  
   auto url = request.getUrl();
 
   auto it = s_handlers.find(url);

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -1,8 +1,6 @@
 // Copyright (c) 2011-2017 The Cryptonote developers
 // Copyright (c) 2017-2018 The Circle Foundation & Conceal Devs
 // Copyright (c) 2018-2019 Conceal Network & Conceal Devs
-// Copyright (c) 2019-2020 The Lithe Project Development Team
-//
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 


### PR DESCRIPTION
### Daemon
* Added clarifying colors to the core daemon.
* Show your peer id when the daemon loads. (Line 5 in the screenshot)

### Misc

* Minor improvements on logging in RpcServer and NetNode
* Stuck to conceals logging format `<< file.cpp << logging`
* Shows your tx hash for sent transactions
* I ported over my colorful daemon commit from; https://github.com/LithyRiolu/lithe/commit/f5954cb5024e8e9f1a446cfaf97c0221a1d4bef6

***

### Screenshots
![conceald-new](https://user-images.githubusercontent.com/49086787/80139409-51af6e80-859e-11ea-99f2-52654cbd7d3b.png)

*this screenshot was ran with `--testnet` so it will look different because of that*
