### PR TITLE
Status

### DIFF
--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -131,6 +131,8 @@ bool core::init(const CoreConfig& config, const MinerConfig& minerConfig, bool l
   m_config_folder = config.configFolder;
   bool r = m_mempool.init(m_config_folder);
 
+  start_time = std::time(nullptr);
+
   if (!(r)) {
     logger(ERROR, BRIGHT_RED) << "<< Core.cpp << " << "Failed to initialize memory pool";
     return false;
@@ -1076,6 +1078,10 @@ bool core::addMessageQueue(MessageQueue<BlockchainMessage>& messageQueue) {
 
 bool core::removeMessageQueue(MessageQueue<BlockchainMessage>& messageQueue) {
   return m_blockchain.removeMessageQueue(messageQueue);
+}
+
+std::time_t core::getStartTime() const {
+  return start_time;
 }
 
 }

--- a/src/CryptoNoteCore/Core.h
+++ b/src/CryptoNoteCore/Core.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <ctime>
 #include <boost/program_options/options_description.hpp>
 #include <boost/program_options/variables_map.hpp>
 
@@ -43,6 +44,8 @@ namespace CryptoNote {
      virtual i_cryptonote_protocol* get_protocol() override {return m_pprotocol;}
      virtual const Currency& currency() const override { return m_currency; }
 
+     virtual std::time_t getStartTime() const;
+
      //-------------------- IMinerHandler -----------------------
      virtual bool handle_block_found(Block& b) override;
      virtual bool get_block_template(Block& b, const AccountPublicAddress& adr, difficulty_type& diffic, uint32_t& height, const BinaryArray& ex_nonce) override;
@@ -55,6 +58,7 @@ namespace CryptoNote {
      bool init(const CoreConfig& config, const MinerConfig& minerConfig, bool load_existing);
      bool set_genesis_block(const Block& b);
      bool deinit();
+     time_t start_time;
 
      // ICore
      virtual size_t addChain(const std::vector<const IBlock*>& chain) override;

--- a/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
+++ b/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.cpp
@@ -162,6 +162,12 @@ std::vector<std::string> CryptoNoteProtocolHandler::all_connections()
   return connections;
 }
 
+uint32_t CryptoNoteProtocolHandler::getBlockchainHeight() {
+  CORE_SYNC_DATA hshd;
+  uint32_t currentChainHeight = hshd.current_height;
+  return currentChainHeight;  
+}
+
 uint32_t CryptoNoteProtocolHandler::get_current_blockchain_height()
 {
   uint32_t height;
@@ -200,6 +206,15 @@ bool CryptoNoteProtocolHandler::process_payload_sync_data(const CORE_SYNC_DATA &
                                                                                           << "Synchronization started";
 
     logger(DEBUGGING) << "Remote top block height: " << hshd.current_height << ", id: " << hshd.top_id;
+    
+    /* pass it through the logger for now */
+    logger(diff >= 0 ? (is_inital ? Logging::INFO : Logging::DEBUGGING) : Logging::TRACE, Logging::BRIGHT_YELLOW) << context <<
+      "Your Conceal node is syncing with the network."
+      << "You are " << std::abs(diff)
+      << " blocks (" << std::abs(diff) / (24 * 60 * 60 / m_currency.difficultyTarget())
+      << " days) " << (diff >= 0 ? std::string("behind") : std::string("ahead"))
+      << "." << std::endl;
+    
     //let the socket to send response to handshake, but request callback, to let send request data after response
     logger(Logging::TRACE) << context << "requesting synchronization";
     context.m_state = CryptoNoteConnectionContext::state_sync_required;
@@ -644,7 +659,8 @@ bool CryptoNoteProtocolHandler::request_missing_objects(CryptoNoteConnectionCont
     requestMissingPoolTransactions(context);
 
     context.m_state = CryptoNoteConnectionContext::state_normal;
-    logger(Logging::INFO, Logging::BRIGHT_GREEN) << "<< CryptonoteProtocolHandler.cpp << " << context << "Synchronization complete";
+    logger(Logging::INFO, Logging::BRIGHT_GREEN) << "<< CryptonoteProtocolHandler.cpp << "
+                                                 << context << "Successfully Synchronized to the Conceal Network.";
     on_connection_synchronized();
   }
   return true;
@@ -687,11 +703,12 @@ bool CryptoNoteProtocolHandler::on_connection_synchronized()
                           << "                                  (@@@@**((((.                                  " << ENDL
                           << "                                     .#***                                      " << ENDL
                           << "  " << ENDL
-                          << "You are now synchronized with the Conceal network. You may now start concealwallet." << ENDL
-                          << "Please note, that the blockchain will be saved only after you quit the daemon" << ENDL
-                          << "with the \"exit\" command or if you use the \"save\" command." << ENDL
-                          << "Otherwise, you will possibly need to synchronize the blockchain again." << ENDL
+                          << ENDL
+                          << "Always exit conceald and concealwallet with the \"exit\" command." << ENDL
+                          << "If you do not exit properly, you may lose your blockchain and wallet data." << ENDL
+                          << ENDL
                           << "Use \"help\" command to see the list of available commands." << ENDL
+                          << "Use \"export_keys\" command to display your keys for restoring a corrupted wallet." << ENDL
                           << "********************************************************************************";
     m_core.on_synchronized();
 
@@ -865,6 +882,7 @@ void CryptoNoteProtocolHandler::recalculateMaxObservedHeight(const CryptoNoteCon
 
 uint32_t CryptoNoteProtocolHandler::getObservedHeight() const
 {
+  uint32_t getBlockchainHeight();
   std::lock_guard<std::mutex> lock(m_observedHeightMutex);
   return m_observedHeight;
 };

--- a/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.h
+++ b/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.h
@@ -72,6 +72,7 @@ namespace CryptoNote
     virtual size_t getPeerCount() const override;
     virtual uint32_t getObservedHeight() const override;
     void requestMissingPoolTransactions(const CryptoNoteConnectionContext& context);
+    uint32_t getBlockchainHeight();
 
   private:
     //----------------- commands handlers ----------------------------------------------

--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -299,7 +299,7 @@ int main(int argc, char* argv[])
 
     cprotocol.set_p2p_endpoint(&p2psrv);
     ccore.set_cryptonote_protocol(&cprotocol);
-    DaemonCommandsHandler dch(ccore, p2psrv, logManager);
+    DaemonCommandsHandler dch(ccore, p2psrv, logManager, &rpcServer);
 
     // initialize objects
     logger(INFO) << "<< Daemon.cpp << " "Initializing p2p server...";

--- a/src/Daemon/DaemonCommandsHandler.cpp
+++ b/src/Daemon/DaemonCommandsHandler.cpp
@@ -4,6 +4,9 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <ctime>
+#include <boost/format.hpp>
+
 #include "DaemonCommandsHandler.h"
 
 #include "P2p/NetNode.h"
@@ -12,6 +15,8 @@
 #include "CryptoNoteCore/Currency.h"
 #include "CryptoNoteProtocol/CryptoNoteProtocolHandler.h"
 #include "Serialization/SerializationTools.h"
+#include "Rpc/RpcServer.h"
+
 #include "version.h"
 
 namespace {
@@ -23,8 +28,8 @@ namespace {
 }
 
 
-DaemonCommandsHandler::DaemonCommandsHandler(CryptoNote::core& core, CryptoNote::NodeServer& srv, Logging::LoggerManager& log) :
-  m_core(core), m_srv(srv), logger(log, "daemon"), m_logManager(log) {
+DaemonCommandsHandler::DaemonCommandsHandler(CryptoNote::core& core, CryptoNote::NodeServer& srv, Logging::LoggerManager& log, CryptoNote::RpcServer* prpc_server) :
+  m_core(core), m_srv(srv), logger(log, "daemon"), m_logManager(log), m_prpc_server(prpc_server) {
   m_consoleHandler.setHandler("exit", boost::bind(&DaemonCommandsHandler::exit, this, _1), "Shutdown the daemon");
   m_consoleHandler.setHandler("help", boost::bind(&DaemonCommandsHandler::help, this, _1), "Show this help");
   m_consoleHandler.setHandler("print_pl", boost::bind(&DaemonCommandsHandler::print_pl, this, _1), "Print peer list");
@@ -41,6 +46,7 @@ DaemonCommandsHandler::DaemonCommandsHandler(CryptoNote::core& core, CryptoNote:
   m_consoleHandler.setHandler("show_hr", boost::bind(&DaemonCommandsHandler::show_hr, this, _1), "Start showing hash rate");
   m_consoleHandler.setHandler("hide_hr", boost::bind(&DaemonCommandsHandler::hide_hr, this, _1), "Stop showing hash rate");
   m_consoleHandler.setHandler("set_log", boost::bind(&DaemonCommandsHandler::set_log, this, _1), "set_log <level> - Change current log level, <level> is a number 0-4");
+  m_consoleHandler.setHandler("status", boost::bind(&DaemonCommandsHandler::status, this, _1), "Shows the daemon status");
 }
 
 //--------------------------------------------------------------------------------
@@ -56,6 +62,46 @@ std::string DaemonCommandsHandler::get_commands_str()
   return ss.str();
 }
 
+//--------------------------------------------------------------------------------
+std::string DaemonCommandsHandler::get_mining_speed(uint32_t hr)
+{
+  if (hr>1e9) return (boost::format("%.2f GH/s") % (hr/1e9)).str();
+  if (hr>1e6) return (boost::format("%.2f MH/s") % (hr/1e6)).str();
+  if (hr>1e3) return (boost::format("%.2f kH/s") % (hr/1e3)).str();
+  return (boost::format("%.0f H/s") % hr).str();
+}
+//--------------------------------------------------------------------------------
+bool DaemonCommandsHandler::status(const std::vector<std::string>& args)
+{
+  CryptoNote::COMMAND_RPC_GET_INFO::request req;
+  CryptoNote::COMMAND_RPC_GET_INFO::response resp;
+
+  if (!m_prpc_server->on_get_info(req, resp) || resp.status != CORE_RPC_STATUS_OK) {
+    std::cout << "Problem retreiving information from RPC server." << std::endl;
+  }
+
+  std::time_t uptime = std::time(nullptr) - resp.start_time;
+
+  std::cout 
+    << "Height: " << resp.height << "/" << resp.last_known_block_index << " (" << get_sync_percentage(resp.height, resp.last_known_block_index) << "%), "
+    << (resp.synced ? "synced, " : "syncing, ") << "on " << (m_core.currency().isTestnet() ? "testnet, " : "mainnet, ")
+    << "net hash " << get_mining_speed(resp.hashrate) << ", " 
+    << resp.outgoing_connections_count << "(out)+" << resp.incoming_connections_count << "(in) connections, "
+    << "uptime " << (unsigned int)floor(uptime / 60.0 / 60.0 / 24.0) << "d " << (unsigned int)floor(fmod((uptime / 60.0 / 60.0), 24.0)) << "h "
+    << (unsigned int)floor(fmod((uptime / 60.0), 60.0)) << "m " << (unsigned int)fmod(uptime, 60.0) << "s"
+    << std::endl;
+
+  return true;
+}
+//--------------------------------------------------------------------------------
+float DaemonCommandsHandler::get_sync_percentage(uint64_t height, uint64_t target_height)
+{
+  target_height = target_height ? target_height < height ? height : target_height : height;
+  float pc = 100.0f * height / target_height;
+  if (height < target_height && pc > 99.9f)
+    return 99.9f; // to avoid 100% when not fully synced
+  return pc;
+}
 //--------------------------------------------------------------------------------
 bool DaemonCommandsHandler::exit(const std::vector<std::string>& args) {
   m_consoleHandler.requestStop();

--- a/src/Daemon/DaemonCommandsHandler.cpp
+++ b/src/Daemon/DaemonCommandsHandler.cpp
@@ -94,13 +94,29 @@ bool DaemonCommandsHandler::status(const std::vector<std::string>& args)
   return true;
 }
 //--------------------------------------------------------------------------------
-float DaemonCommandsHandler::get_sync_percentage(uint64_t height, uint64_t target_height)
+std::string DaemonCommandsHandler::get_sync_percentage(uint64_t height, uint64_t target_height)
 {
-  target_height = target_height ? target_height < height ? height : target_height : height;
-  float pc = 100.0f * height / target_height;
-  if (height < target_height && pc > 99.9f)
-    return 99.9f; // to avoid 100% when not fully synced
-  return pc;
+  /* Don't divide by zero */
+  if (height == 0 || target_height == 0) {
+    return "0.00";
+  }
+
+  /* So we don't have > 100% */
+  if (height > target_height) {
+    height = target_height;
+  }
+
+  float percent = 100.0f * height / target_height;
+
+  if (height < target_height && percent > 99.99f) {
+    percent = 99.99f; // to avoid 100% when not fully synced
+  }
+
+  std::stringstream stream;
+
+  stream << std::setprecision(2) << std::fixed << percent;
+
+  return stream.str();
 }
 //--------------------------------------------------------------------------------
 bool DaemonCommandsHandler::exit(const std::vector<std::string>& args) {

--- a/src/Daemon/DaemonCommandsHandler.h
+++ b/src/Daemon/DaemonCommandsHandler.h
@@ -72,5 +72,5 @@ private:
   
   bool status(const std::vector<std::string>& args);
   std::string get_mining_speed(uint32_t hr);
-  float get_sync_percentage(uint64_t height, uint64_t target_height);
+  std::string get_sync_percentage(uint64_t height, uint64_t target_height);
 };

--- a/src/Daemon/DaemonCommandsHandler.h
+++ b/src/Daemon/DaemonCommandsHandler.h
@@ -11,6 +11,10 @@
 #include <Logging/LoggerRef.h>
 #include <Logging/LoggerManager.h>
 
+#include "Rpc/RpcServer.h"
+#include "Rpc/CoreRpcServerCommandsDefinitions.h"
+#include "Rpc/JsonRpc.h"
+
 namespace CryptoNote {
 class core;
 class Currency;
@@ -20,7 +24,7 @@ class NodeServer;
 class DaemonCommandsHandler
 {
 public:
-  DaemonCommandsHandler(CryptoNote::core& core, CryptoNote::NodeServer& srv, Logging::LoggerManager& log);
+  DaemonCommandsHandler(CryptoNote::core& core, CryptoNote::NodeServer& srv, Logging::LoggerManager& log, CryptoNote::RpcServer* prpc_server);
 
   bool start_handling() {
     m_consoleHandler.start();
@@ -38,6 +42,7 @@ private:
   CryptoNote::NodeServer& m_srv;
   Logging::LoggerRef logger;
   Logging::LoggerManager& m_logManager;
+  CryptoNote::RpcServer* m_prpc_server;
 
   std::string get_commands_str();
   bool print_block_by_height(uint32_t height);
@@ -64,4 +69,8 @@ private:
 
   bool start_mining(const std::vector<std::string>& args);
   bool stop_mining(const std::vector<std::string>& args);
+  
+  bool status(const std::vector<std::string>& args);
+  std::string get_mining_speed(uint32_t hr);
+  float get_sync_percentage(uint64_t height, uint64_t target_height);
 };

--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -35,10 +35,12 @@ struct COMMAND_RPC_GET_HEIGHT {
 
   struct response {
     uint64_t height;
+    uint32_t last_known_block_index;
     std::string status;
 
     void serialize(ISerializer &s) {
       KV_MEMBER(height)
+      KV_MEMBER(last_known_block_index)
       KV_MEMBER(status)
     }
   };
@@ -277,6 +279,9 @@ struct COMMAND_RPC_GET_INFO {
     uint64_t last_block_timestamp;
     uint64_t last_block_difficulty;
     std::vector<std::string> connections;
+    uint32_t hashrate;
+    bool synced;
+    uint64_t start_time;
 
     void serialize(ISerializer &s) {
       KV_MEMBER(status)
@@ -299,7 +304,9 @@ struct COMMAND_RPC_GET_INFO {
       KV_MEMBER(last_block_reward)
       KV_MEMBER(last_block_timestamp)
       KV_MEMBER(last_block_difficulty)
-      KV_MEMBER(connections)      
+      KV_MEMBER(connections)
+      KV_MEMBER(hashrate)
+      KV_MEMBER(synced)  
     }
   };
 };

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -614,10 +614,10 @@ bool RpcServer::on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RP
   res.incoming_connections_count = total_conn - res.outgoing_connections_count;
   res.white_peerlist_size = m_p2p.getPeerlistManager().get_white_peers_count();
   res.grey_peerlist_size = m_p2p.getPeerlistManager().get_gray_peers_count();
-  res.last_known_block_index = std::max(static_cast<uint32_t>(1), m_protocolQuery.getObservedHeight()) - 1;
+  res.last_known_block_index = std::max(static_cast<uint32_t>(1), m_protocolQuery.getObservedHeight());
   res.full_deposit_amount = m_core.fullDepositAmount();
   res.status = CORE_RPC_STATUS_OK;
-  Crypto::Hash last_block_hash = m_core.getBlockIdByHeight(m_core.get_current_blockchain_height() - 1);
+  Crypto::Hash last_block_hash = m_core.getBlockIdByHeight(m_core.get_current_blockchain_height());
   res.top_block_hash = Common::podToHex(last_block_hash);
   res.version = PROJECT_VERSION;
   res.hashrate = (uint32_t)round(res.difficulty / CryptoNote::parameters::DIFFICULTY_TARGET);

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -7,6 +7,7 @@
 #include "RpcServer.h"
 
 #include <future>
+#include "math.h"
 #include <unordered_map>
 
 // CryptoNote
@@ -21,11 +22,13 @@
 #include "CryptoNoteCore/Miner.h"
 #include "CryptoNoteCore/TransactionExtra.h"
 #include "CryptoNoteProtocol/ICryptoNoteProtocolQuery.h"
+#include "CryptoNoteConfig.h"
 
 #include "P2p/NetNode.h"
 
 #include "CoreRpcServerErrorCodes.h"
 #include "JsonRpc.h"
+
 #include "version.h"
 
 #undef ERROR
@@ -617,7 +620,10 @@ bool RpcServer::on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RP
   Crypto::Hash last_block_hash = m_core.getBlockIdByHeight(m_core.get_current_blockchain_height() - 1);
   res.top_block_hash = Common::podToHex(last_block_hash);
   res.version = PROJECT_VERSION;
-
+  res.hashrate = (uint32_t)round(res.difficulty / CryptoNote::parameters::DIFFICULTY_TARGET);
+  res.synced = ((uint32_t)res.height == (uint32_t)res.last_known_block_index);
+  res.start_time = m_core.getStartTime();
+ 
   Block blk;
   if (!m_core.getBlockByHash(last_block_hash, blk)) {
 	  throw JsonRpc::JsonRpcError{
@@ -650,6 +656,7 @@ bool RpcServer::on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RP
 
 bool RpcServer::on_get_height(const COMMAND_RPC_GET_HEIGHT::request& req, COMMAND_RPC_GET_HEIGHT::response& res) {
   res.height = m_core.get_current_blockchain_height();
+  res.last_known_block_index = std::max(static_cast<uint32_t>(1), m_protocolQuery.getObservedHeight());
   res.status = CORE_RPC_STATUS_OK;
   return true;
 }

--- a/src/Rpc/RpcServer.h
+++ b/src/Rpc/RpcServer.h
@@ -4,6 +4,8 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#pragma once
+
 #include "HttpServer.h"
 
 #include <functional>
@@ -22,6 +24,7 @@ class ICryptoNoteProtocolQuery;
 class RpcServer : public HttpServer {
 public:
   RpcServer(System::Dispatcher& dispatcher, Logging::ILogger& log, core& c, NodeServer& p2p, const ICryptoNoteProtocolQuery& protocolQuery);
+  
   typedef std::function<bool(RpcServer*, const HttpRequest& request, HttpResponse& response)> HandlerFunction;
   bool setFeeAddress(const std::string& fee_address, const AccountPublicAddress& fee_acc);
   bool setViewKey(const std::string& view_key);
@@ -30,7 +33,8 @@ public:
   bool k_on_check_reserve_proof(const K_COMMAND_RPC_CHECK_RESERVE_PROOF::request& req, K_COMMAND_RPC_CHECK_RESERVE_PROOF::response& res);  
   bool enableCors(const std::string domain);  
   bool remotenode_check_incoming_tx(const BinaryArray& tx_blob);
-
+  bool on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res);
+  
 private:
 
   template <class Handler>
@@ -56,7 +60,6 @@ private:
   bool onGetPoolChangesLite(const COMMAND_RPC_GET_POOL_CHANGES_LITE::request& req, COMMAND_RPC_GET_POOL_CHANGES_LITE::response& rsp);
 
   // json handlers
-  bool on_get_info(const COMMAND_RPC_GET_INFO::request& req, COMMAND_RPC_GET_INFO::response& res);
   bool on_get_height(const COMMAND_RPC_GET_HEIGHT::request& req, COMMAND_RPC_GET_HEIGHT::response& res);
   bool on_get_peer_list(const COMMAND_RPC_GET_PEER_LIST::request& req, COMMAND_RPC_GET_PEER_LIST::response& res);
   bool on_get_transactions(const COMMAND_RPC_GET_TRANSACTIONS::request& req, COMMAND_RPC_GET_TRANSACTIONS::response& res);


### PR DESCRIPTION
### Daemon
* removed false fully synced prompt
* add a syncing logger to the daemon
* new command `status`

### Misc
* new net hash and sync percent functions
* added time tracking to the daemon using `ctime`
* add last_known_block_index to getHeight call
* fixes last_known_block_index to be new real blockchain height
* better syncing percentage

***

### Usage
* Typing `status` into `conceald` will show something similar to this;
`Height: 86362/496235 (17.40%), syncing, on mainnet, net hash 145.56 kH/s, 8(out)+0(in) connections, uptime 0d 0h 12m 0s`
* As the `conceald` is syncing, you will be prompted with something similar to this;
`00:28:36.032294 INFO [95.165.96.59:15000 OUT] Your Conceal node is syncing with the network.You are 345563 blocks (479 days) behind.`

***
**Dev Note:** the new function `CryptoNoteProtocolHandler::getBlockchainHeight()` will get the real blockchain height whereas `m_core.get_current_blockchain_height()` actually returns the daemon height