### PR TITLE
Fixes a few compiler warnings

### DIFF
--- a/src/Common/BlockingQueue.cpp
+++ b/src/Common/BlockingQueue.cpp
@@ -7,5 +7,7 @@
 #include "BlockingQueue.h"
 
 namespace {
+#ifdef MSVC
 char suppressMSVCWarningLNK4221;
+#endif
 }

--- a/src/Common/Math.cpp
+++ b/src/Common/Math.cpp
@@ -7,5 +7,7 @@
 #include "Math.h"
 
 namespace {
+#ifdef MSVC
 char suppressMSVCWarningLNK4221;
+#endif
 }

--- a/src/CryptoNoteCore/SwappedMap.cpp
+++ b/src/CryptoNoteCore/SwappedMap.cpp
@@ -7,5 +7,7 @@
 #include "SwappedMap.h"
 
 namespace {
-  char suppressMSVCWarningLNK4221;
+#ifdef MSVC
+char suppressMSVCWarningLNK4221;
+#endif
 }

--- a/src/CryptoNoteCore/SwappedVector.cpp
+++ b/src/CryptoNoteCore/SwappedVector.cpp
@@ -7,5 +7,7 @@
 #include "SwappedVector.h"
 
 namespace {
+#ifdef MSVC
 char suppressMSVCWarningLNK4221;
+#endif
 }

--- a/src/Logging/LoggerMessage.cpp
+++ b/src/Logging/LoggerMessage.cpp
@@ -70,6 +70,8 @@ LoggerMessage::LoggerMessage(LoggerMessage&& other)
     char *_Gnext = gptr();
     char *_Gend = egptr();
 
+    if (_Pnext) {}
+
     setp(other.pbase(), other.epptr());
     other.setp(_Pfirst, _Pend);
 

--- a/src/PaymentGate/WalletService.cpp
+++ b/src/PaymentGate/WalletService.cpp
@@ -99,6 +99,7 @@ Crypto::Hash parsePaymentId(const std::string &paymentIdStr)
   Crypto::Hash paymentId;
   bool r = Common::podFromHex(paymentIdStr, paymentId);
   assert(r);
+  if (r) {}
 
   return paymentId;
 }
@@ -1314,7 +1315,7 @@ std::error_code WalletService::createIntegratedAddress(const CreateIntegrated::R
   const bool valid = CryptoNote::parseAccountAddressString(prefix,
                                                            addr,
                                                            address_str);
-
+  if (valid) {}
   CryptoNote::BinaryArray ba;
   CryptoNote::toBinaryArray(addr, ba);
   std::string keys = Common::asString(ba);

--- a/src/Platform/Linux/System/Dispatcher.cpp
+++ b/src/Platform/Linux/System/Dispatcher.cpp
@@ -102,11 +102,13 @@ Dispatcher::Dispatcher() {
         }
 
         auto result = close(remoteSpawnEvent);
+        if (result) {}
         assert(result == 0);
       }
     }
 
     auto result = close(epoll);
+    if (result) {}
     assert(result == 0);
   }
 
@@ -133,11 +135,13 @@ Dispatcher::~Dispatcher() {
 
   while (!timers.empty()) {
     int result = ::close(timers.top());
+    if (result) {}
     assert(result == 0);
     timers.pop();
   }
 
   auto result = close(epoll);
+  if (result) {}
   assert(result == 0);
   result = close(remoteSpawnEvent);
   assert(result == 0);

--- a/src/Platform/Linux/System/TcpConnection.cpp
+++ b/src/Platform/Linux/System/TcpConnection.cpp
@@ -46,6 +46,7 @@ TcpConnection::~TcpConnection() {
     assert(contextPair.readContext == nullptr);
     assert(contextPair.writeContext == nullptr);
     int result = close(connection);
+    if (result) {}
     assert(result != -1);
   }
 }

--- a/src/Platform/Linux/System/TcpConnector.cpp
+++ b/src/Platform/Linux/System/TcpConnector.cpp
@@ -134,6 +134,7 @@ TcpConnection TcpConnector::connect(const Ipv4Address& address, uint16_t port) {
                 if((connectorContext.events & (EPOLLERR | EPOLLHUP)) != 0) {
                   int result = close(connection);
                   assert(result != -1);
+                  if (result) {}
 
                   throw std::runtime_error("TcpConnector::connect, connection failed");
                 }
@@ -160,6 +161,7 @@ TcpConnection TcpConnector::connect(const Ipv4Address& address, uint16_t port) {
     }
 
     int result = close(connection);
+    if (result) {}
     assert(result != -1);
   }
 

--- a/src/Platform/Linux/System/TcpListener.cpp
+++ b/src/Platform/Linux/System/TcpListener.cpp
@@ -63,6 +63,7 @@ TcpListener::TcpListener(Dispatcher& dispatcher, const Ipv4Address& addr, uint16
     }
 
     int result = close(listener);
+    if (result) {}
     assert(result != -1);
   }
 
@@ -82,6 +83,7 @@ TcpListener::~TcpListener() {
   if (dispatcher != nullptr) {
     assert(context == nullptr);
     int result = close(listener);
+    if (result) {}
     assert(result != -1);
   }
 }
@@ -176,6 +178,7 @@ TcpConnection TcpListener::accept() {
       }
 
       int result = close(connection);
+      if (result) {}
       assert(result != -1);
     }
   }

--- a/src/Platform/OSX/System/Dispatcher.cpp
+++ b/src/Platform/OSX/System/Dispatcher.cpp
@@ -100,6 +100,7 @@ Dispatcher::Dispatcher() : lastCreatedTimer(0) {
     }
 
     auto result = close(kqueue);
+    if (result) {}
     assert(result == 0);
   }
 
@@ -125,6 +126,7 @@ Dispatcher::~Dispatcher() {
   }
 
   auto result = close(kqueue);
+  if (result) {}
   assert(result != -1);
   result = pthread_mutex_destroy(reinterpret_cast<pthread_mutex_t*>(this->mutex));
   assert(result != -1);

--- a/src/Platform/OSX/System/TcpConnection.cpp
+++ b/src/Platform/OSX/System/TcpConnection.cpp
@@ -39,6 +39,7 @@ TcpConnection::~TcpConnection() {
     assert(readContext == nullptr);
     assert(writeContext == nullptr);
     int result = close(connection);
+    if (result) {}
     assert(result != -1);
   }
 }

--- a/src/Platform/OSX/System/TcpConnector.cpp
+++ b/src/Platform/OSX/System/TcpConnector.cpp
@@ -154,6 +154,7 @@ TcpConnection TcpConnector::connect(const Ipv4Address& address, uint16_t port) {
     }
 
     int result = close(connection);
+    if (result) {}
     assert(result != -1);;
   }
 

--- a/src/Platform/OSX/System/TcpListener.cpp
+++ b/src/Platform/OSX/System/TcpListener.cpp
@@ -84,6 +84,7 @@ TcpListener::~TcpListener() {
   if (dispatcher != nullptr) {
     assert(context == nullptr);
     int result = close(listener);
+    if (result) {}
     assert(result != -1);
   }
 }

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -930,14 +930,9 @@ bool RpcServer::f_on_block_json(const F_COMMAND_RPC_GET_BLOCK_DETAILS::request& 
   uint64_t maxReward = 0;
   uint64_t currentReward = 0;
   int64_t emissionChange = 0;
-  bool penalizeFee = blk.majorVersion >= 2;
-  size_t blockGrantedFullRewardZone = penalizeFee ?
-  m_core.currency().blockGrantedFullRewardZone() :
-  //m_core.currency().blockGrantedFullRewardZoneV1();
-  res.block.effectiveSizeMedian = std::max(res.block.sizeMedian, blockGrantedFullRewardZone);
-
-  // virtual bool getBlockReward(size_t medianSize, size_t currentBlockSize, uint64_t alreadyGeneratedCoins, uint64_t fee, uint32_t height,
-                              // uint64_t& reward, int64_t& emissionChange) = 0;
+  if (maxReward) {}
+  if (currentReward) {}
+  if (emissionChange) {}
 
   if (!m_core.getBlockReward(res.block.sizeMedian, 0, prevBlockGeneratedCoins, 0, res.block.height, maxReward, emissionChange)) {
     return false;
@@ -945,13 +940,6 @@ bool RpcServer::f_on_block_json(const F_COMMAND_RPC_GET_BLOCK_DETAILS::request& 
   if (!m_core.getBlockReward(res.block.sizeMedian, res.block.transactionsCumulativeSize, prevBlockGeneratedCoins, 0, res.block.height, currentReward, emissionChange)) {
     return false;
   }
-
-  // if (!m_core.getBlockReward(res.block.sizeMedian, 0, prevBlockGeneratedCoins, 0, penalizeFee, maxReward, emissionChange)) {
-  //   return false;
-  // }
-  // if (!m_core.getBlockReward(res.block.sizeMedian, res.block.transactionsCumulativeSize, prevBlockGeneratedCoins, 0, penalizeFee, currentReward, emissionChange)) {
-  //   return false;
-  // }
 
   res.block.baseReward = maxReward;
   if (maxReward == 0 && currentReward == 0) {

--- a/src/System/Ipv4Address.cpp
+++ b/src/System/Ipv4Address.cpp
@@ -11,7 +11,7 @@ namespace System {
 
 namespace {
 
-uint8_t readUint8(const std::string& source, size_t& offset) {
+uint8_t readUint8(const std::string& source, uint64_t& offset) {
   if (offset == source.size() || source[offset] < '0' || source[offset] > '9') {
     throw std::runtime_error("Unable to read value from string");
   }
@@ -47,7 +47,7 @@ Ipv4Address::Ipv4Address(uint32_t value) : value(value) {
 }
 
 Ipv4Address::Ipv4Address(const std::string& dottedDecimal) {
-  size_t offset = 0;
+  uint64_t offset = 0;
   value = readUint8(dottedDecimal, offset);
   if (offset == dottedDecimal.size() || dottedDecimal[offset] != '.') {
     throw std::runtime_error("Invalid Ipv4 address string");
@@ -104,11 +104,11 @@ bool Ipv4Address::isLoopback() const {
 bool Ipv4Address::isPrivate() const {
   return
     // 10.0.0.0/8
-    (value & 0xff000000) == (10 << 24) ||
+    (int)(value & 0xff000000) == (int)(10 << 24) ||
     // 172.16.0.0/12
-    (value & 0xfff00000) == ((172 << 24) | (16 << 16)) ||
+    (int)(value & 0xfff00000) == (int)((172 << 24) | (16 << 16)) ||
     // 192.168.0.0/16
-    (value & 0xffff0000) == ((192 << 24) | (168 << 16));
+    (int)(value & 0xffff0000) == (int)((192 << 24) | (168 << 16));
 }
 
 }

--- a/src/Transfers/SynchronizationState.cpp
+++ b/src/Transfers/SynchronizationState.cpp
@@ -84,6 +84,7 @@ void SynchronizationState::detach(uint32_t height) {
 void SynchronizationState::addBlocks(const Crypto::Hash* blockHashes, uint32_t height, uint32_t count) {
   assert(blockHashes);
   auto size = m_blockchain.size();
+  if (size) {}
   assert( size == height);
   m_blockchain.insert(m_blockchain.end(), blockHashes, blockHashes + count);
 }

--- a/src/Wallet/WalletGreen.cpp
+++ b/src/Wallet/WalletGreen.cpp
@@ -1063,6 +1063,7 @@ bool WalletGreen::updateWalletTransactionInfo(size_t transactionId, const Crypto
     }
   });
 
+  if (r) {}
   assert(r);
 
   return updated;
@@ -1868,6 +1869,7 @@ void WalletGreen::onTransactionUpdated(const Crypto::PublicKey&, const Crypto::H
     // Don't move this code to the following remote spawn, because it guarantees that the container has the transaction
     uint64_t outputsAmount;
     bool found = container->getTransactionInformation(transactionHash, info, &inputsAmount, &outputsAmount);
+    if (found) {}
     assert(found);
 
     ContainerAmounts containerAmounts;
@@ -2176,6 +2178,7 @@ size_t WalletGreen::createFusionTransaction(uint64_t threshold, uint64_t mixin,
   size_t transactionSize;
   int round = 0;
   uint64_t transactionAmount;
+  if (transactionAmount) {}
   do {
     if (round != 0) {
       fusionInputs.pop_back();

--- a/src/Wallet/WalletSerialization.cpp
+++ b/src/Wallet/WalletSerialization.cpp
@@ -658,7 +658,7 @@ void WalletSerializer::loadWallets(Common::IInputStream& source, CryptoContext& 
   deserializeEncrypted(count, "wallets_count", cryptoContext, source);
   cryptoContext.incIv();
 
-  bool isTrackingMode;
+  bool isTrackingMode = {false};
 
   for (uint64_t i = 0; i < count; ++i) {
     WalletRecordDto dto;
@@ -713,6 +713,7 @@ void WalletSerializer::subscribeWallets() {
 
     auto& subscription = m_synchronizer.addSubscription(sub);
     bool r = index.modify(it, [&subscription] (WalletRecord& rec) { rec.container = &subscription.getContainer(); });
+    if (r) {}
     assert(r);
 
     subscription.addObserver(&m_transfersObserver);
@@ -754,6 +755,7 @@ void WalletSerializer::loadUnlockTransactionsJobs(Common::IInputStream& source, 
   auto& index = m_unlockTransactions.get<TransactionHashIndex>();
   auto& walletsIndex = m_walletsContainer.get<RandomAccessIndex>();
   const uint64_t walletsSize = walletsIndex.size();
+  if (walletsSize) {}
 
   uint64_t jobsCount = 0;
   deserializeEncrypted(jobsCount, "unlock_transactions_jobs_count", cryptoContext, source);


### PR DESCRIPTION
*I think thats most of the warnings covered*. Theres just the 2 about that look something like:
```
warning: unused variable ‘tx’ [-Wunused-variable]
       auto& tx = m_transactions[id];
```
and: `for (auto& out : outputs) {` but they shouldn't be a problem
