### PR TITLE
Deterministic transaction keys

### DIFF
--- a/include/BinaryArray.hpp
+++ b/include/BinaryArray.hpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2012-2018, The CryptoNote developers, The Bytecoin developers.
+// Licensed under the GNU Lesser General Public License. See LICENSE for details.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+#include <CryptoNote.h>
+
+using namespace CryptoNote;
+
+namespace Common {
+
+template<class It>
+inline BinaryArray::iterator append(BinaryArray &ba, It be, It en) {
+	return ba.insert(ba.end(), be, en);
+}
+inline BinaryArray::iterator append(BinaryArray &ba, size_t add, BinaryArray::value_type va) {
+	return ba.insert(ba.end(), add, va);
+}
+inline BinaryArray::iterator append(BinaryArray &ba, const BinaryArray &other) {
+	return ba.insert(ba.end(), other.begin(), other.end());
+}
+
+} // namespace Common

--- a/include/CryptoNote.h
+++ b/include/CryptoNote.h
@@ -48,10 +48,12 @@ struct TransactionOutput {
   TransactionOutputTarget target;
 };
 
+using TransactionInputs = std::vector<TransactionInput>;
+
 struct TransactionPrefix {
   uint8_t version;
   uint64_t unlockTime;
-  std::vector<TransactionInput> inputs;
+  TransactionInputs inputs;
   std::vector<TransactionOutput> outputs;
   std::vector<uint8_t> extra;
 };

--- a/include/CryptoTypes.h
+++ b/include/CryptoTypes.h
@@ -14,12 +14,22 @@ struct Hash {
   uint8_t data[32];
 };
 
-struct PublicKey {
+struct EllipticCurvePoint
+{
   uint8_t data[32];
 };
 
-struct SecretKey {
+struct EllipticCurveScalar
+{
   uint8_t data[32];
+};
+
+struct PublicKey : public EllipticCurvePoint
+{
+};
+
+struct SecretKey : public EllipticCurveScalar
+{
 };
 
 struct KeyDerivation {
@@ -34,4 +44,7 @@ struct Signature {
   uint8_t data[64];
 };
 
+const struct EllipticCurveScalar I = {{0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
+
 }
+

--- a/include/INode.h
+++ b/include/INode.h
@@ -78,7 +78,7 @@ public:
   virtual void queryBlocks(std::vector<Crypto::Hash>&& knownBlockIds, uint64_t timestamp, std::vector<BlockShortEntry>& newBlocks, uint32_t& startHeight, const Callback& callback) = 0;
   virtual void getPoolSymmetricDifference(std::vector<Crypto::Hash>&& knownPoolTxIds, Crypto::Hash knownBlockId, bool& isBcActual, std::vector<std::unique_ptr<ITransactionReader>>& newTxs, std::vector<Crypto::Hash>& deletedTxIds, const Callback& callback) = 0;
   virtual void getMultisignatureOutputByGlobalIndex(uint64_t amount, uint32_t gindex, MultisignatureOutput& out, const Callback& callback) = 0;
-
+  virtual void getTransaction(const Crypto::Hash &transactionHash, CryptoNote::Transaction &transaction, const Callback &callback) = 0;
   virtual void getBlocks(const std::vector<uint32_t>& blockHeights, std::vector<std::vector<BlockDetails>>& blocks, const Callback& callback) = 0;
   virtual void getBlocks(const std::vector<Crypto::Hash>& blockHashes, std::vector<BlockDetails>& blocks, const Callback& callback) = 0;
   virtual void getBlocks(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t blocksNumberLimit, std::vector<BlockDetails>& blocks, uint32_t& blocksNumberWithinTimestamps, const Callback& callback) = 0;

--- a/include/ITransaction.h
+++ b/include/ITransaction.h
@@ -49,6 +49,7 @@ public:
 
   virtual Crypto::Hash getTransactionHash() const = 0;
   virtual Crypto::Hash getTransactionPrefixHash() const = 0;
+  virtual Crypto::Hash getTransactionInputsHash() const = 0;
   virtual Crypto::PublicKey getTransactionPublicKey() const = 0;
   virtual bool getTransactionSecretKey(Crypto::SecretKey& key) const = 0;
   virtual uint64_t getUnlockTime() const = 0;
@@ -64,7 +65,7 @@ public:
   virtual TransactionTypes::InputType getInputType(size_t index) const = 0;
   virtual void getInput(size_t index, KeyInput& input) const = 0;
   virtual void getInput(size_t index, MultisignatureInput& input) const = 0;
-
+  virtual std::vector<TransactionInput> getInputs() const = 0;
   // outputs
   virtual size_t getOutputCount() const = 0;
   virtual uint64_t getOutputTotalAmount() const = 0;
@@ -83,6 +84,7 @@ public:
 
   // serialized transaction
   virtual BinaryArray getTransactionData() const = 0;
+  virtual TransactionPrefix getTransactionPrefix() const = 0;
 };
 
 //

--- a/src/Common/BinaryArray.hpp
+++ b/src/Common/BinaryArray.hpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2012-2018, The CryptoNote developers, The Bytecoin developers.
+// Licensed under the GNU Lesser General Public License. See LICENSE for details.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+#include <CryptoNote.h>
+
+using namespace CryptoNote;
+
+namespace Common
+{
+
+    template <class It>
+    inline BinaryArray::iterator append(BinaryArray &ba, It be, It en)
+    {
+        return ba.insert(ba.end(), be, en);
+    }
+    inline BinaryArray::iterator append(BinaryArray &ba, size_t add, BinaryArray::value_type va)
+    {
+        return ba.insert(ba.end(), add, va);
+    }
+    inline BinaryArray::iterator append(BinaryArray &ba, const BinaryArray &other)
+    {
+        return ba.insert(ba.end(), other.begin(), other.end());
+    }
+
+} // namespace Common

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.h
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <boost/utility/value_init.hpp>
-
+#include <CryptoNote.h>
 #include "CryptoNoteBasic.h"
 #include "CryptoNoteSerialization.h"
 
@@ -46,6 +46,9 @@ struct tx_message_entry
   bool encrypt;
   AccountPublicAddress addr;
 };
+
+bool generateDeterministicTransactionKeys(const Crypto::Hash &inputsHash, const Crypto::SecretKey &viewSecretKey, KeyPair &generatedKeys);
+bool generateDeterministicTransactionKeys(const Transaction &tx, const Crypto::SecretKey &viewSecretKey, KeyPair &generatedKeys);
 
 bool constructTransaction(
   const AccountKeys& senderAccountKeys,

--- a/src/CryptoNoteCore/CryptoNoteSerialization.cpp
+++ b/src/CryptoNoteCore/CryptoNoteSerialization.cpp
@@ -265,6 +265,12 @@ void serialize(MultisignatureInput& multisignature, ISerializer& serializer) {
   serializer(multisignature.term, "term");
 }
 
+
+void serialize(TransactionInputs & inputs, ISerializer & serializer) {
+  serializer(inputs, "vin");
+}
+
+
 void serialize(TransactionOutput& output, ISerializer& serializer) {
   serializer(output.amount, "amount");
   serializer(output.target, "target");

--- a/src/CryptoNoteCore/CryptoNoteSerialization.h
+++ b/src/CryptoNoteCore/CryptoNoteSerialization.h
@@ -49,6 +49,7 @@ void serialize(TransactionExtraMergeMiningTag& tag, ISerializer& serializer);
 
 void serialize(AccountPublicAddress& address, ISerializer& serializer);
 void serialize(AccountKeys& keys, ISerializer& s);
+void serialize(TransactionInputs &inputs, ISerializer &serializer);
 
 void serialize(KeyPair& keyPair, ISerializer& serializer);
 

--- a/src/CryptoNoteCore/Transaction.cpp
+++ b/src/CryptoNoteCore/Transaction.cpp
@@ -47,6 +47,7 @@ namespace CryptoNote {
     // ITransactionReader
     virtual Hash getTransactionHash() const override;
     virtual Hash getTransactionPrefixHash() const override;
+    virtual Hash getTransactionInputsHash() const override;
     virtual PublicKey getTransactionPublicKey() const override;
     virtual uint64_t getUnlockTime() const override;
     virtual bool getPaymentId(Hash& hash) const override;
@@ -59,6 +60,7 @@ namespace CryptoNote {
     virtual TransactionTypes::InputType getInputType(size_t index) const override;
     virtual void getInput(size_t index, KeyInput& input) const override;
     virtual void getInput(size_t index, MultisignatureInput& input) const override;
+    virtual std::vector<TransactionInput> getInputs() const override;
 
     // outputs
     virtual size_t getOutputCount() const override;
@@ -77,7 +79,7 @@ namespace CryptoNote {
 
     // get serialized transaction
     virtual BinaryArray getTransactionData() const override;
-
+    TransactionPrefix getTransactionPrefix() const override;
     // ITransactionWriter
 
     virtual void setUnlockTime(uint64_t unlockTime) override;
@@ -204,6 +206,11 @@ namespace CryptoNote {
     checkIfSigning();
     transaction.unlockTime = unlockTime;
     invalidateHash();
+  }
+
+  Hash TransactionImpl::getTransactionInputsHash() const
+  {
+    return getObjectHash(transaction.inputs);
   }
 
   bool TransactionImpl::getTransactionSecretKey(SecretKey& key) const {
@@ -394,6 +401,11 @@ namespace CryptoNote {
     return toBinaryArray(transaction);
   }
 
+  TransactionPrefix TransactionImpl::getTransactionPrefix() const
+  {
+    return transaction;
+  }
+
   void TransactionImpl::setPaymentId(const Hash& hash) {
     checkIfSigning();
     BinaryArray paymentIdBlob;
@@ -463,6 +475,11 @@ namespace CryptoNote {
 
   size_t TransactionImpl::getOutputCount() const {
     return transaction.outputs.size();
+  }
+
+  std::vector<TransactionInput> TransactionImpl::getInputs() const
+  {
+    return transaction.inputs;
   }
 
   uint64_t TransactionImpl::getOutputTotalAmount() const {

--- a/src/CryptoNoteCore/TransactionPrefixImpl.cpp
+++ b/src/CryptoNoteCore/TransactionPrefixImpl.cpp
@@ -27,6 +27,7 @@ public:
 
   virtual Hash getTransactionHash() const override;
   virtual Hash getTransactionPrefixHash() const override;
+  virtual Hash getTransactionInputsHash() const override;
   virtual PublicKey getTransactionPublicKey() const override;
   virtual uint64_t getUnlockTime() const override;
 
@@ -41,6 +42,7 @@ public:
   virtual TransactionTypes::InputType getInputType(size_t index) const override;
   virtual void getInput(size_t index, KeyInput& input) const override;
   virtual void getInput(size_t index, MultisignatureInput& input) const override;
+  virtual std::vector<TransactionInput> getInputs() const override;
 
   // outputs
   virtual size_t getOutputCount() const override;
@@ -60,7 +62,7 @@ public:
 
   // serialized transaction
   virtual BinaryArray getTransactionData() const override;
-
+  virtual TransactionPrefix getTransactionPrefix() const override;
   virtual bool getTransactionSecretKey(SecretKey& key) const override;
 
 private:
@@ -85,6 +87,11 @@ Hash TransactionPrefixImpl::getTransactionHash() const {
 
 Hash TransactionPrefixImpl::getTransactionPrefixHash() const {
   return getObjectHash(m_txPrefix);
+}
+
+Hash TransactionPrefixImpl::getTransactionInputsHash() const
+{
+  return getObjectHash(m_txPrefix.inputs);
 }
 
 PublicKey TransactionPrefixImpl::getTransactionPublicKey() const {
@@ -166,6 +173,11 @@ void TransactionPrefixImpl::getOutput(size_t index, KeyOutput& output, uint64_t&
   amount = out.amount;
 }
 
+std::vector<TransactionInput> TransactionPrefixImpl::getInputs() const
+{
+  return m_txPrefix.inputs;
+}
+
 void TransactionPrefixImpl::getOutput(size_t index, MultisignatureOutput& output, uint64_t& amount) const {
   const auto& out = getOutputChecked(m_txPrefix, index, TransactionTypes::OutputType::Multisignature);
   output = boost::get<MultisignatureOutput>(out.target);
@@ -198,6 +210,11 @@ bool TransactionPrefixImpl::validateSignatures() const {
 
 BinaryArray TransactionPrefixImpl::getTransactionData() const {
   return toBinaryArray(m_txPrefix);
+}
+
+TransactionPrefix TransactionPrefixImpl::getTransactionPrefix() const
+{
+  return m_txPrefix;
 }
 
 bool TransactionPrefixImpl::getTransactionSecretKey(SecretKey& key) const {

--- a/src/InProcessNode/InProcessNode.h
+++ b/src/InProcessNode/InProcessNode.h
@@ -61,6 +61,7 @@ public:
 
   virtual void getBlocks(const std::vector<uint32_t>& blockHeights, std::vector<std::vector<BlockDetails>>& blocks, const Callback& callback) override;
   virtual void getBlocks(const std::vector<Crypto::Hash>& blockHashes, std::vector<BlockDetails>& blocks, const Callback& callback) override;
+  virtual void getTransaction(const Crypto::Hash &transactionHash, CryptoNote::Transaction &transaction, const Callback &callback) override;
   virtual void getBlocks(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t blocksNumberLimit, std::vector<BlockDetails>& blocks, uint32_t& blocksNumberWithinTimestamps, const Callback& callback) override;
   virtual void getTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<TransactionDetails>& transactions, const Callback& callback) override;
   virtual void getTransactionsByPaymentId(const Crypto::Hash& paymentId, std::vector<TransactionDetails>& transactions, const Callback& callback) override;
@@ -118,6 +119,8 @@ private:
   void isSynchronizedAsync(bool& syncStatus, const Callback& callback);
   std::error_code doIsSynchronized(bool& syncStatus);
 
+  void getTransactionAsync(const Crypto::Hash &transactionHash, CryptoNote::Transaction &transaction, const Callback &callback);
+  std::error_code doGetTransaction(const Crypto::Hash &transactionHash, CryptoNote::Transaction &transaction);
   void workerFunc();
   bool doShutdown();
 

--- a/src/NodeRpcProxy/NodeRpcProxy.cpp
+++ b/src/NodeRpcProxy/NodeRpcProxy.cpp
@@ -22,6 +22,7 @@
 
 #include "Common/StringTools.h"
 #include "CryptoNoteCore/CryptoNoteBasicImpl.h"
+#include "CryptoNoteCore/CryptoNoteFormatUtils.h"
 #include "CryptoNoteCore/CryptoNoteTools.h"
 #include "Rpc/CoreRpcServerCommandsDefinitions.h"
 #include "Rpc/HttpClient.h"
@@ -416,6 +417,7 @@ void NodeRpcProxy::getBlocks(const std::vector<Crypto::Hash>& blockHashes, std::
   callback(std::error_code());
 }
 
+
 void NodeRpcProxy::getTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<TransactionDetails>& transactions, const Callback& callback) {
   std::lock_guard<std::mutex> lock(m_mutex);
   if (m_state != STATE_INITIALIZED) {
@@ -579,6 +581,52 @@ std::error_code NodeRpcProxy::doGetPoolSymmetricDifference(std::vector<Crypto::H
   }
 
   return ec;
+}
+
+std::error_code NodeRpcProxy::doGetTransaction(const Crypto::Hash &transactionHash, CryptoNote::Transaction &transaction)
+{
+  COMMAND_RPC_GET_TRANSACTIONS::request req = AUTO_VAL_INIT(req);
+  COMMAND_RPC_GET_TRANSACTIONS::response resp = AUTO_VAL_INIT(resp);
+
+  req.txs_hashes.push_back(Common::podToHex(transactionHash));
+
+  std::error_code ec = jsonCommand("/gettransactions", req, resp);
+  if (ec)
+  {
+    return ec;
+  }
+
+  if (resp.missed_tx.size() > 0)
+  {
+    return make_error_code(CryptoNote::error::REQUEST_ERROR);
+  }
+
+  BinaryArray tx_blob;
+  if (!Common::fromHex(resp.txs_as_hex[0], tx_blob))
+  {
+    return make_error_code(error::INTERNAL_NODE_ERROR);
+  }
+
+  Crypto::Hash tx_hash = NULL_HASH;
+  Crypto::Hash tx_prefixt_hash = NULL_HASH;
+  if (!parseAndValidateTransactionFromBinaryArray(tx_blob, transaction, tx_hash, tx_prefixt_hash) || tx_hash != transactionHash)
+  {
+    return make_error_code(error::INTERNAL_NODE_ERROR);
+  }
+
+  return ec;
+}
+
+void NodeRpcProxy::getTransaction(const Crypto::Hash &transactionHash, CryptoNote::Transaction &transaction, const Callback &callback)
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+  if (m_state != STATE_INITIALIZED)
+  {
+    callback(make_error_code(error::NOT_INITIALIZED));
+    return;
+  }
+
+  scheduleRequest(std::bind(&NodeRpcProxy::doGetTransaction, this, std::cref(transactionHash), std::ref(transaction)), callback);
 }
 
 void NodeRpcProxy::scheduleRequest(std::function<std::error_code()>&& procedure, const Callback& callback) {

--- a/src/NodeRpcProxy/NodeRpcProxy.h
+++ b/src/NodeRpcProxy/NodeRpcProxy.h
@@ -95,9 +95,11 @@ private:
     std::vector<CryptoNote::BlockShortEntry>& newBlocks, uint32_t& startHeight);
   std::error_code doGetPoolSymmetricDifference(std::vector<Crypto::Hash>&& knownPoolTxIds, Crypto::Hash knownBlockId, bool& isBcActual,
           std::vector<std::unique_ptr<ITransactionReader>>& newTxs, std::vector<Crypto::Hash>& deletedTxIds);
+  virtual void getTransaction(const Crypto::Hash &transactionHash, CryptoNote::Transaction &transaction, const Callback &callback) override;
+  std::error_code doGetTransaction(const Crypto::Hash &transactionHash, CryptoNote::Transaction &transaction);
 
   void scheduleRequest(std::function<std::error_code()>&& procedure, const Callback& callback);
-  template <typename Request, typename Response>
+template <typename Request, typename Response>
   std::error_code binaryCommand(const std::string& url, const Request& req, Response& res);
   template <typename Request, typename Response>
   std::error_code jsonCommand(const std::string& url, const Request& req, Response& res);

--- a/src/PaymentGate/NodeFactory.cpp
+++ b/src/PaymentGate/NodeFactory.cpp
@@ -61,6 +61,7 @@ public:
 
   virtual void getTransactions(const std::vector<Crypto::Hash>& transactionHashes, std::vector<CryptoNote::TransactionDetails>& transactions,
     const Callback& callback) override { }
+  virtual void getTransaction(const Crypto::Hash &transactionHash, CryptoNote::Transaction &transaction, const Callback &callback) override {}
 
   virtual void getPoolTransactions(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t transactionsNumberLimit, std::vector<CryptoNote::TransactionDetails>& transactions, uint64_t& transactionsNumberWithinTimestamps,
     const Callback& callback) override { }

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -34,7 +34,6 @@ using namespace Logging;
 using namespace Crypto;
 using namespace Common;
 
-static const Crypto::SecretKey I = { { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } };
 
 
 namespace CryptoNote {
@@ -290,11 +289,12 @@ bool RpcServer::k_on_check_tx_proof(const K_COMMAND_RPC_CHECK_TX_PROOF::request&
 
 		// obtain key derivation by multiplying scalar 1 to the pubkey r*A included in the signature
 		Crypto::KeyDerivation derivation;
-		if (!Crypto::generate_key_derivation(rA, I, derivation)) {
-			throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Failed to generate key derivation" };
-		}
+    if (!Crypto::generate_key_derivation(rA, Crypto::EllipticCurveScalar2SecretKey(Crypto::I), derivation))
+    {
+      throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Failed to generate key derivation" };
+    }
 
-		// get tx pub key
+    // get tx pub key
 		Crypto::PublicKey txPubKey = getTransactionPublicKeyFromExtra(transaction.extra);
 
 		// look for outputs
@@ -421,10 +421,11 @@ bool RpcServer::k_on_check_reserve_proof(const K_COMMAND_RPC_CHECK_RESERVE_PROOF
 
 		// check if the address really received the fund
 		Crypto::KeyDerivation derivation;
-		if (!Crypto::generate_key_derivation(proof.shared_secret, I, derivation)) {
-			throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Failed to generate key derivation" };
-		}
-		try {
+    if (!Crypto::generate_key_derivation(proof.shared_secret, Crypto::EllipticCurveScalar2SecretKey(Crypto::I), derivation))
+    {
+      throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Failed to generate key derivation" };
+    }
+    try {
 			Crypto::PublicKey pubkey;
 			derive_public_key(derivation, proof.index_in_tx, address.spendPublicKey, pubkey);
 			if (pubkey == out_key.key) {

--- a/src/Transfers/TransfersConsumer.cpp
+++ b/src/Transfers/TransfersConsumer.cpp
@@ -378,7 +378,18 @@ std::error_code createTransfers(
   auto txPubKey = tx.getTransactionPublicKey();
   auto txHash = tx.getTransactionHash();
   std::vector<PublicKey> temp_keys;	
-  std::lock_guard<std::mutex> lk(seen_mutex);	
+  std::lock_guard<std::mutex> lk(seen_mutex);
+
+  if (account.spendSecretKey == NULL_SECRET_KEY)
+  {
+    KeyPair deterministic_tx_keys;
+    bool spending = generateDeterministicTransactionKeys(tx.getTransactionInputsHash(), account.viewSecretKey, deterministic_tx_keys) && deterministic_tx_keys.publicKey == txPubKey;
+
+    if (spending)
+    {
+      //m_logger(WARNING, BRIGHT_YELLOW) << "Spending in tx " << Common::podToHex(tx.getTransactionHash());
+    }
+  }
 
   for (auto idx : outputs) {
 

--- a/src/Wallet/WalletGreen.cpp
+++ b/src/Wallet/WalletGreen.cpp
@@ -411,6 +411,37 @@ namespace CryptoNote
     size_t id = validateSaveAndSendTransaction(*transaction, {}, false, true);
   }
 
+  Crypto::SecretKey WalletGreen::getTransactionDeterministicSecretKey(Crypto::Hash &transactionHash) const
+  {
+    throwIfNotInitialized();
+    throwIfStopped();
+
+    Crypto::SecretKey txKey = CryptoNote::NULL_SECRET_KEY;
+
+    auto getTransactionCompleted = std::promise<std::error_code>();
+    auto getTransactionWaitFuture = getTransactionCompleted.get_future();
+    CryptoNote::Transaction tx;
+    m_node.getTransaction(std::move(transactionHash), std::ref(tx),
+                          [&getTransactionCompleted](std::error_code ec) {
+                            auto detachedPromise = std::move(getTransactionCompleted);
+                            detachedPromise.set_value(ec);
+                          });
+    std::error_code ec = getTransactionWaitFuture.get();
+    if (ec)
+    {
+      m_logger(ERROR) << "Failed to get tx: " << ec << ", " << ec.message();
+      return CryptoNote::NULL_SECRET_KEY;
+    }
+
+    Crypto::PublicKey txPubKey = getTransactionPublicKeyFromExtra(tx.extra);
+    KeyPair deterministicTxKeys;
+    bool ok = generateDeterministicTransactionKeys(tx, m_viewSecretKey, deterministicTxKeys) && deterministicTxKeys.publicKey == txPubKey;
+
+    return ok ? deterministicTxKeys.secretKey : CryptoNote::NULL_SECRET_KEY;
+
+    return txKey;
+  }
+
   std::vector<MultisignatureInput> WalletGreen::prepareMultisignatureInputs(const std::vector<TransactionOutputInformation> &selectedTransfers)
   {
     std::vector<MultisignatureInput> inputs;

--- a/src/Wallet/WalletGreen.h
+++ b/src/Wallet/WalletGreen.h
@@ -143,6 +143,8 @@ protected:
   void initWithKeys(const std::string& path, const std::string& password, const Crypto::PublicKey& viewPublicKey, const Crypto::SecretKey& viewSecretKey);
   std::string doCreateAddress(const Crypto::PublicKey &spendPublicKey, const Crypto::SecretKey &spendSecretKey, uint64_t creationTimestamp);
   std::vector<std::string> doCreateAddressList(const std::vector<NewAddressData> &addressDataList);
+  Crypto::SecretKey getTransactionDeterministicSecretKey(Crypto::Hash &transactionHash) const;
+
   uint64_t scanHeightToTimestamp(const uint32_t scanHeight);
   uint64_t getCurrentTimestampAdjusted();
 

--- a/src/crypto/crypto-util.h
+++ b/src/crypto/crypto-util.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2012-2018, The CryptoNote developers, The Bytecoin developers.
+// Licensed under the GNU Lesser General Public License. See LICENSE for details.
+
+// Copyright (c) 2013-2018
+// Frank Denis <j at pureftpd dot org>
+// See https://github.com/jedisct1/libsodium/blob/master/LICENSE for details
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+// We borrow from https://libsodium.org/
+void sodium_memzero(void *pnt, size_t length);
+int sodium_compare(const void *a1, const void *a2, size_t length);
+
+#if defined(__cplusplus)
+}
+#endif

--- a/src/crypto/crypto.cpp
+++ b/src/crypto/crypto.cpp
@@ -55,9 +55,10 @@ namespace Crypto {
     memcpy(&res, tmp, 32);
   }
 
-  static inline void hash_to_scalar(const void *data, size_t length, EllipticCurveScalar &res) {
+  void hash_to_scalar(const void *data, size_t length, EllipticCurveScalar &res)
+  {
     cn_fast_hash(data, length, reinterpret_cast<Hash &>(res));
-    sc_reduce32(reinterpret_cast<unsigned char*>(&res));
+    sc_reduce32(reinterpret_cast<unsigned char *>(&res));
   }
 
   void crypto_ops::generate_keys(PublicKey &pub, SecretKey &sec) {

--- a/src/crypto/crypto.h
+++ b/src/crypto/crypto.h
@@ -25,14 +25,6 @@ namespace Crypto {
 
   extern std::mutex random_lock;
 
-struct EllipticCurvePoint {
-  uint8_t data[32];
-};
-
-struct EllipticCurveScalar {
-  uint8_t data[32];
-};
-
   class crypto_ops {
     crypto_ops();
     crypto_ops(const crypto_ops &);
@@ -132,6 +124,8 @@ struct EllipticCurveScalar {
       return rand<T>();
     }
   };
+
+  void hash_to_scalar(const void *data, size_t length, EllipticCurveScalar &res);
 
   /* Generate a new key pair
    */
@@ -269,6 +263,7 @@ struct EllipticCurveScalar {
     return check_ring_signature(prefix_hash, image, pubs.data(), pubs.size(), sig);
   }
 
+  static inline const SecretKey &EllipticCurveScalar2SecretKey(const EllipticCurveScalar &k) { return (const SecretKey &)k; }
 }
 
 CRYPTO_MAKE_HASHABLE(PublicKey)


### PR DESCRIPTION
Introduces support for deterministic transactions keys, also known as secret keys. Previously, a user needed to note down the secret key as soon as the transaction is sent. Now starting from the latest version of the wallet, we generated the secret key based on the inputs of the transactions, which enables us to get the secret key for the transaction at any point to provide proof of payment or that funds were sent to a specific address. 