### PR TITLE
`save_keys` command in concealwallet

### DIFF
--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -614,6 +614,7 @@ simple_wallet::simple_wallet(System::Dispatcher& dispatcher, const CryptoNote::C
   m_consoleHandler.setHandler("help", boost::bind(&simple_wallet::help, this, boost::arg<1>()), "Show this help");
   m_consoleHandler.setHandler("exit", boost::bind(&simple_wallet::exit, this, boost::arg<1>()), "Close wallet");  
   m_consoleHandler.setHandler("get_reserve_proof", boost::bind(&simple_wallet::get_reserve_proof, this, boost::arg<1>()), "all|<amount> [<message>] - Generate a signature proving that you own at least <amount>, optionally with a challenge string <message>. ");
+  m_consoleHandler.setHandler("save_keys", boost::bind(&simple_wallet::save_keys_to_file, this, boost::arg<1>()), "Save wallet private keys to \"conceal_keys_backup.txt\"");
 }
 
 /* This function shows the number of outputs in the wallet
@@ -1927,6 +1928,33 @@ void simple_wallet::printConnectionError() const {
   fail_msg_writer() << "wallet failed to connect to daemon (" << m_daemon_address << ").";
 }
 
+bool simple_wallet::save_keys_to_file(const std::vector<std::string>& args)
+{
+  std::ofstream backup_file("conceal_keys_backup.txt");
+  AccountKeys keys;
+  m_wallet->getAccountKeys(keys);
+
+  std::string priv_key = "\t\tConceal Keys Backup\n\n";
+  priv_key += "Wallet file name: " + m_wallet_file + "\n";
+  priv_key += "Private spend key: " + Common::podToHex(keys.spendSecretKey) + "\n";
+  priv_key += "Private view key: " +  Common::podToHex(keys.viewSecretKey) + "\n";
+
+  Crypto::PublicKey unused_dummy_variable;
+  Crypto::SecretKey deterministic_private_view_key;
+
+  AccountBase::generateViewFromSpend(keys.spendSecretKey, deterministic_private_view_key, unused_dummy_variable);
+  bool deterministic_private_keys = deterministic_private_view_key == keys.viewSecretKey;
+
+  /* dont show a mnemonic seed if it is an old non-deterministic wallet */
+  if (deterministic_private_keys)
+    priv_key += "Mnemonic seed: " + generate_mnemonic(keys.spendSecretKey) + "\n";
+
+  backup_file << priv_key;
+
+  logger(INFO, BRIGHT_GREEN) << "Wallet keys have been saved to the current folder where \"concealwallet\" is located.";
+
+  return true;
+}
 
 int main(int argc, char* argv[]) {
 #ifdef _WIN32

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -94,8 +94,8 @@ namespace CryptoNote
     bool save(const std::vector<std::string> &args);
     bool reset(const std::vector<std::string> &args);
     bool set_log(const std::vector<std::string> &args);
+    bool save_keys_to_file(const std::vector<std::string> &args);
 
-    bool ask_wallet_create_if_needed();
     std::string resolveAlias(const std::string& aliasUrl);
     void printConnectionError() const;
 


### PR DESCRIPTION
Exports private keys to a simple .txt file. Users tend to copy their private keys into a new text file so this saves a job.

#### `save_keys` output
```
		Conceal Keys Backup

Wallet file name: my_first.wallet
Private spend key: bfb...
Private view key: 0f1...
Mnemonic seed: nylon nobody umbrella ...
```

https://github.com/cartoon-face/Mimosa/pull/5