### PR TITLE
Remove unused variable from Logging

### DIFF
--- a/src/Logging/LoggerMessage.cpp
+++ b/src/Logging/LoggerMessage.cpp
@@ -64,7 +64,6 @@ LoggerMessage::LoggerMessage(LoggerMessage&& other)
 
     //streambuf swap
     char *_Pfirst = pbase();
-    char *_Pnext = pptr();
     char *_Pend = epptr();
     char *_Gfirst = eback();
     char *_Gnext = gptr();


### PR DESCRIPTION
`std::streambuf::setp(char, char)` doesn't need or use `pptr()` as it only needs 2 char inputs, currently occupied by `pbase()` and `epptr()`