### PR TITLE
SonarCloud

### DIFF
--- a/include/ITransaction.h
+++ b/include/ITransaction.h
@@ -109,7 +109,7 @@ public:
   virtual size_t addInput(const AccountKeys& senderKeys, const transaction_types::InputKeyInfo& info, KeyPair& ephKeys) = 0;
 
   virtual size_t addOutput(uint64_t amount, const AccountPublicAddress& to) = 0;
-  virtual size_t addOutput(uint64_t amount, const std::vector<AccountPublicAddress>& to, uint32_t requiredSignatures, uint32_t term = 0) = 0;
+  virtual size_t addOutput(uint64_t amount, const std::vector<AccountPublicAddress>& to, uint8_t requiredSignatures, uint32_t term = 0) = 0;
   virtual size_t addOutput(uint64_t amount, const KeyOutput& out) = 0;
   virtual size_t addOutput(uint64_t amount, const MultisignatureOutput& out) = 0;
 

--- a/src/CryptoNoteCore/Account.cpp
+++ b/src/CryptoNoteCore/Account.cpp
@@ -27,7 +27,7 @@ void AccountBase::generateViewFromSpend(crypto::SecretKey &spend, crypto::Secret
 void AccountBase::generate() {
   crypto::generate_keys(m_keys.address.spendPublicKey, m_keys.spendSecretKey);
   generateViewFromSpend(m_keys.spendSecretKey, m_keys.viewSecretKey, m_keys.address.viewPublicKey);
-  m_creation_timestamp = time(NULL);
+  m_creation_timestamp = time(nullptr);
 }
 //-----------------------------------------------------------------
 const AccountKeys &AccountBase::getAccountKeys() const {

--- a/src/CryptoNoteCore/BlockIndex.cpp
+++ b/src/CryptoNoteCore/BlockIndex.cpp
@@ -51,7 +51,7 @@ namespace cn {
     std::vector<crypto::Hash> result;
     if (getBlockHeight(startBlockId, startBlockHeight))
     {
-      size_t sparseChainEnd = static_cast<size_t>(startBlockHeight + 1);
+      auto sparseChainEnd = static_cast<size_t>(startBlockHeight + 1);
       for (size_t i = 1; i <= sparseChainEnd; i *= 2)
       {
         result.emplace_back(m_container[sparseChainEnd - i]);

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -57,8 +57,8 @@ namespace std
   }
 } // namespace std
 
-#define CURRENT_BLOCKCACHE_STORAGE_ARCHIVE_VER 4
-#define CURRENT_BLOCKCHAININDICES_STORAGE_ARCHIVE_VER 1
+const uint8_t CURRENT_BLOCKCACHE_STORAGE_ARCHIVE_VER = 4;
+const uint8_t CURRENT_BLOCKCHAININDICES_STORAGE_ARCHIVE_VER = 1;
 
 namespace cn
 {
@@ -606,10 +606,10 @@ namespace cn
 
     update_next_comulative_size_limit();
 
-    uint64_t timestamp_diff = time(NULL) - m_blocks.back().bl.timestamp;
+    uint64_t timestamp_diff = time(nullptr) - m_blocks.back().bl.timestamp;
     if (!m_blocks.back().bl.timestamp)
     {
-      timestamp_diff = time(NULL) - 1341378000;
+      timestamp_diff = time(nullptr) - 1341378000;
     }
 
     logger(INFO, BRIGHT_GREEN)
@@ -680,7 +680,7 @@ namespace cn
           }
           else if (i.type() == typeid(MultisignatureInput))
           {
-            auto out = ::boost::get<MultisignatureInput>(i);
+            const auto out = ::boost::get<MultisignatureInput>(i);
             m_multisignatureOutputs[out.amount][out.outputIndex].isUsed = true;
           }
         }
@@ -879,7 +879,7 @@ namespace cn
       commulative_difficulties.push_back(m_blocks[offset].cumulative_difficulty);
     }
 
-    uint64_t block_index = m_blocks.size();
+    uint32_t block_index = m_blocks.size();
     uint8_t block_major_version = get_block_major_version_for_height(block_index + 1);
 
     if (block_major_version >= 8)
@@ -972,7 +972,7 @@ namespace cn
       popBlock(get_block_hash(m_blocks.back().bl));
     }
 
-    uint32_t height = static_cast<uint32_t>(rollback_height - 1);
+    auto height = static_cast<uint32_t>(rollback_height - 1);
 
     // return back original chain
     for (auto &bl : original_chain)
@@ -1020,7 +1020,7 @@ namespace cn
     }
     for (auto alt_ch_iter = alt_chain.begin(); alt_ch_iter != alt_chain.end(); alt_ch_iter++)
     {
-      auto ch_ent = *alt_ch_iter;
+      const auto ch_ent = *alt_ch_iter;
       Block b = ch_ent->second.bl;
       std::copy(b.transactionHashes.begin(), b.transactionHashes.end(), std::inserter(altChainTxHashes, altChainTxHashes.end()));
     }
@@ -2083,7 +2083,7 @@ namespace cn
     else
     {
       //interpret as time
-      uint64_t current_time = static_cast<uint64_t>(time(NULL));
+      uint64_t current_time = static_cast<uint64_t>(time(nullptr));
       if (current_time + m_currency.lockedTxAllowedDeltaSeconds() >= unlock_time)
         return true;
       else
@@ -2170,7 +2170,7 @@ namespace cn
   uint64_t Blockchain::get_adjusted_time()
   {
     //TODO: add collecting median time
-    return time(NULL);
+    return time(nullptr);
   }
 
   bool Blockchain::check_tx_outputs(const Transaction &tx) const

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -867,7 +867,7 @@ namespace cn
 
     uint8_t BlockMajorVersion = getBlockMajorVersionForHeight(static_cast<uint32_t>(m_blocks.size()));
 
-    size_t offset = m_blocks.size() - std::min(m_blocks.size(), m_currency.difficultyBlocksCountByBlockVersion(BlockMajorVersion));
+    size_t offset = m_blocks.size() - std::min(m_blocks.size(), m_currency.difficultyBlocksCountByBlockVersion(static_cast<uint8_t>(BlockMajorVersion)));
     if (offset == 0)
     {
       ++offset;

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -2098,7 +2098,7 @@ namespace cn
       outputs_visitor(std::vector<const crypto::PublicKey *> &results_collector, Blockchain &bch, ILogger &logger) : m_results_collector(results_collector), m_bch(bch), logger(logger, "outputs_visitor")
       {
       }
-
+ 
       bool handle_output(const Transaction &tx, const TransactionOutput &out)
       {
         //check tx unlock time

--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -867,7 +867,7 @@ namespace cn
 
     uint8_t BlockMajorVersion = getBlockMajorVersionForHeight(static_cast<uint32_t>(m_blocks.size()));
 
-    size_t offset = m_blocks.size() - std::min(m_blocks.size(), m_currency.difficultyBlocksCountByBlockVersion(static_cast<uint8_t>(BlockMajorVersion)));
+    size_t offset = m_blocks.size() - std::min(m_blocks.size(), static_cast<uint64_t>(m_currency.difficultyBlocksCountByBlockVersion(BlockMajorVersion)));
     if (offset == 0)
     {
       ++offset;

--- a/src/CryptoNoteCore/BlockchainIndices.cpp
+++ b/src/CryptoNoteCore/BlockchainIndices.cpp
@@ -131,7 +131,7 @@ bool TimestampTransactionsIndex::find(uint64_t timestampBegin, uint64_t timestam
   }
   auto begin = index.lower_bound(timestampBegin);
   auto end = index.upper_bound(timestampEnd);
-  if (timestampEnd == static_cast<uint64_t>(0) && end == begin && begin == index.begin() && index.size() > 0)
+  if (timestampEnd == static_cast<uint64_t>(0) && end == begin && begin == index.begin() && !index.empty())
 	  ++end; //fix for genesis non-zero timestamp
 
   hashesNumberWithinTimestamps = static_cast<uint32_t>(std::distance(begin, end));

--- a/src/CryptoNoteCore/BlockchainIndices.h
+++ b/src/CryptoNoteCore/BlockchainIndices.h
@@ -30,7 +30,7 @@ public:
   void serialize(ISerializer& s);
 
   template<class Archive> 
-  void serialize(Archive& archive, unsigned int version) {
+  void serialize(Archive& archive) {
     archive & index;
   }
 private:
@@ -49,7 +49,7 @@ public:
   void serialize(ISerializer& s);
 
   template<class Archive> 
-  void serialize(Archive& archive, unsigned int version) {
+  void serialize(Archive& archive) {
     archive & index;
   }
 private:
@@ -68,7 +68,7 @@ public:
   void serialize(ISerializer& s);
 
   template<class Archive>
-  void serialize(Archive& archive, unsigned int version) {
+  void serialize(Archive& archive) {
     archive & index;
   }
 private:
@@ -87,7 +87,7 @@ public:
   void serialize(ISerializer& s);
 
   template<class Archive> 
-  void serialize(Archive& archive, unsigned int version) {
+  void serialize(Archive& archive) {
     archive & index;
     archive & lastGeneratedTxNumber;
   }

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -917,9 +917,9 @@ bool core::scanOutputkeysForIndices(const KeyInput& txInToKey, std::list<std::pa
   {
     std::list<std::pair<crypto::Hash, size_t>>& m_resultsCollector;
     outputs_visitor(std::list<std::pair<crypto::Hash, size_t>>& resultsCollector):m_resultsCollector(resultsCollector){}
-    bool handle_output(const Transaction& tx, const TransactionOutput& out, size_t transactionOutputIndex)
+    bool handle_output(const Transaction& tx, const TransactionOutput& out)
     {
-      m_resultsCollector.push_back(std::make_pair(getObjectHash(tx), transactionOutputIndex));
+      getObjectHash(tx);
       return true;
     }
   };

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -915,6 +915,14 @@ bool core::scanOutputkeysForIndices(const KeyInput& txInToKey, std::list<std::pa
     outputs_visitor(std::list<std::pair<crypto::Hash, size_t>>& resultsCollector):m_resultsCollector(resultsCollector){}
     bool handle_output(const Transaction& tx, const TransactionOutput &out)
     {
+      if (out.target.type() != typeid(KeyOutput))
+      {
+        // make this pass through the logger function
+        //logger(ERROR, BRIGHT_RED) << "Output have wrong type id, which=" << out.target.which();
+        std::cout << "Output have wrong type id, which=" << out.target.which() << std::endl;
+        return false;
+      }
+
       getObjectHash(tx);
       return true;
     }

--- a/src/CryptoNoteCore/Core.h
+++ b/src/CryptoNoteCore/Core.h
@@ -38,14 +38,14 @@ namespace cn {
      ~core();
 
      bool on_idle() override;
-     virtual bool handle_incoming_tx(const BinaryArray& tx_blob, tx_verification_context& tvc, bool keeped_by_block) override; //Deprecated. Should be removed with CryptoNoteProtocolHandler.
+     bool handle_incoming_tx(const BinaryArray& tx_blob, tx_verification_context& tvc, bool keeped_by_block) override; //Deprecated. Should be removed with CryptoNoteProtocolHandler.
      bool handle_incoming_block_blob(const BinaryArray& block_blob, block_verification_context& bvc, bool control_miner, bool relay_block) override;
-     virtual i_cryptonote_protocol* get_protocol() override {return m_pprotocol;}
-     virtual const Currency& currency() const override { return m_currency; }
+     i_cryptonote_protocol* get_protocol() override {return m_pprotocol;}
+     const Currency& currency() const override { return m_currency; }
 
      //-------------------- IMinerHandler -----------------------
-     virtual bool handle_block_found(Block& b) override;
-     virtual bool get_block_template(Block& b, const AccountPublicAddress& adr, difficulty_type& diffic, uint32_t& height, const BinaryArray& ex_nonce) override;
+     bool handle_block_found(Block& b) override;
+     bool get_block_template(Block& b, const AccountPublicAddress& adr, difficulty_type& diffic, uint32_t& height, const BinaryArray& ex_nonce) override;
 
      bool addObserver(ICoreObserver* observer) override;
      bool removeObserver(ICoreObserver* observer) override;
@@ -57,31 +57,31 @@ namespace cn {
      bool deinit();
 
      // ICore
-     virtual bool saveBlockchain() override;
-     virtual size_t addChain(const std::vector<const IBlock*>& chain) override;
-     virtual bool handle_get_objects(NOTIFY_REQUEST_GET_OBJECTS_request& arg, NOTIFY_RESPONSE_GET_OBJECTS_request& rsp) override; //Deprecated. Should be removed with CryptoNoteProtocolHandler.
-     virtual bool getBackwardBlocksSizes(uint32_t fromHeight, std::vector<size_t>& sizes, size_t count) override;
-     virtual bool getBlockSize(const crypto::Hash& hash, size_t& size) override;
-     virtual bool getAlreadyGeneratedCoins(const crypto::Hash& hash, uint64_t& generatedCoins) override;
-     virtual bool getBlockReward(size_t medianSize, size_t currentBlockSize, uint64_t alreadyGeneratedCoins, uint64_t fee, uint32_t height,
+     bool saveBlockchain() override;
+     size_t addChain(const std::vector<const IBlock*>& chain) override;
+     bool handle_get_objects(NOTIFY_REQUEST_GET_OBJECTS_request& arg, NOTIFY_RESPONSE_GET_OBJECTS_request& rsp) override; //Deprecated. Should be removed with CryptoNoteProtocolHandler.
+     bool getBackwardBlocksSizes(uint32_t fromHeight, std::vector<size_t>& sizes, size_t count) override;
+     bool getBlockSize(const crypto::Hash& hash, size_t& size) override;
+     bool getAlreadyGeneratedCoins(const crypto::Hash& hash, uint64_t& generatedCoins) override;
+     bool getBlockReward(size_t medianSize, size_t currentBlockSize, uint64_t alreadyGeneratedCoins, uint64_t fee, uint32_t height,
                                  uint64_t& reward, int64_t& emissionChange) override;
-     virtual bool scanOutputkeysForIndices(const KeyInput& txInToKey, std::list<std::pair<crypto::Hash, size_t>>& outputReferences) override;
-     virtual bool getBlockDifficulty(uint32_t height, difficulty_type& difficulty) override;
-     virtual bool getBlockTimestamp(uint32_t height, uint64_t &timestamp) override;
-     virtual bool getBlockContainingTx(const crypto::Hash& txId, crypto::Hash& blockId, uint32_t& blockHeight) override;
-     virtual bool getMultisigOutputReference(const MultisignatureInput& txInMultisig, std::pair<crypto::Hash, size_t>& output_reference) override;
-     virtual bool getGeneratedTransactionsNumber(uint32_t height, uint64_t& generatedTransactions) override;
-     virtual bool getOrphanBlocksByHeight(uint32_t height, std::vector<Block>& blocks) override;
-     virtual bool getBlocksByTimestamp(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t blocksNumberLimit, std::vector<Block>& blocks, uint32_t& blocksNumberWithinTimestamps) override;
-     virtual bool getPoolTransactionsByTimestamp(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t transactionsNumberLimit, std::vector<Transaction>& transactions, uint64_t& transactionsNumberWithinTimestamps) override;
-     virtual bool getTransactionsByPaymentId(const crypto::Hash& paymentId, std::vector<Transaction>& transactions) override;
-     virtual bool getOutByMSigGIndex(uint64_t amount, uint64_t gindex, MultisignatureOutput& out) override;
-     virtual std::unique_ptr<IBlock> getBlock(const crypto::Hash& blocksId) override;
-     virtual bool handleIncomingTransaction(const Transaction& tx, const crypto::Hash& txHash, size_t blobSize, tx_verification_context& tvc, bool keptByBlock, uint32_t height) override;
-     virtual std::error_code executeLocked(const std::function<std::error_code()>& func) override;
+     bool scanOutputkeysForIndices(const KeyInput& txInToKey, std::list<std::pair<crypto::Hash, size_t>>& outputReferences) override;
+     bool getBlockDifficulty(uint32_t height, difficulty_type& difficulty) override;
+     bool getBlockTimestamp(uint32_t height, uint64_t &timestamp) override;
+     bool getBlockContainingTx(const crypto::Hash& txId, crypto::Hash& blockId, uint32_t& blockHeight) override;
+     bool getMultisigOutputReference(const MultisignatureInput& txInMultisig, std::pair<crypto::Hash, size_t>& output_reference) override;
+     bool getGeneratedTransactionsNumber(uint32_t height, uint64_t& generatedTransactions) override;
+     bool getOrphanBlocksByHeight(uint32_t height, std::vector<Block>& blocks) override;
+     bool getBlocksByTimestamp(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t blocksNumberLimit, std::vector<Block>& blocks, uint32_t& blocksNumberWithinTimestamps) override;
+     bool getPoolTransactionsByTimestamp(uint64_t timestampBegin, uint64_t timestampEnd, uint32_t transactionsNumberLimit, std::vector<Transaction>& transactions, uint64_t& transactionsNumberWithinTimestamps) override;
+     bool getTransactionsByPaymentId(const crypto::Hash& paymentId, std::vector<Transaction>& transactions) override;
+     bool getOutByMSigGIndex(uint64_t amount, uint64_t gindex, MultisignatureOutput& out) override;
+     std::unique_ptr<IBlock> getBlock(const crypto::Hash& blocksId) override;
+     bool handleIncomingTransaction(const Transaction& tx, const crypto::Hash& txHash, size_t blobSize, tx_verification_context& tvc, bool keptByBlock, uint32_t height) override;
+     std::error_code executeLocked(const std::function<std::error_code()>& func) override;
      
-     virtual bool addMessageQueue(MessageQueue<BlockchainMessage>& messageQueue) override;
-     virtual bool removeMessageQueue(MessageQueue<BlockchainMessage>& messageQueue) override;
+     bool addMessageQueue(MessageQueue<BlockchainMessage>& messageQueue) override;
+     bool removeMessageQueue(MessageQueue<BlockchainMessage>& messageQueue) override;
 
      uint32_t get_current_blockchain_height();
      bool have_block(const crypto::Hash& id) override;
@@ -89,7 +89,7 @@ namespace cn {
      std::vector<crypto::Hash> buildSparseChain(const crypto::Hash& startBlockId) override;
      void on_synchronized() override;
 
-     virtual void get_blockchain_top(uint32_t& height, crypto::Hash& top_id) override;
+     void get_blockchain_top(uint32_t& height, crypto::Hash& top_id) override;
      bool get_blocks(uint32_t start_offset, uint32_t count, std::list<Block>& blocks, std::list<Transaction>& txs);
      bool get_blocks(uint32_t start_offset, uint32_t count, std::list<Block>& blocks);
      bool rollback_chain_to(uint32_t height);
@@ -98,15 +98,15 @@ namespace cn {
      {
        return m_blockchain.getBlocks(block_ids, blocks, missed_bs);
      }
-     virtual bool queryBlocks(const std::vector<crypto::Hash>& block_ids, uint64_t timestamp,
+    bool queryBlocks(const std::vector<crypto::Hash>& block_ids, uint64_t timestamp,
        uint32_t& start_height, uint32_t& current_height, uint32_t& full_offset, std::vector<BlockFullInfo>& entries) override;
-    virtual bool queryBlocksLite(const std::vector<crypto::Hash>& knownBlockIds, uint64_t timestamp,
+    bool queryBlocksLite(const std::vector<crypto::Hash>& knownBlockIds, uint64_t timestamp,
       uint32_t& resStartHeight, uint32_t& resCurrentHeight, uint32_t& resFullOffset, std::vector<BlockShortInfo>& entries) override;
-    virtual crypto::Hash getBlockIdByHeight(uint32_t height) override;
-    virtual bool getTransaction(const crypto::Hash &id, Transaction &tx, bool checkTxPool = false) override;
+    crypto::Hash getBlockIdByHeight(uint32_t height) override;
+    bool getTransaction(const crypto::Hash &id, Transaction &tx, bool checkTxPool = false) override;
     void getTransactions(const std::vector<crypto::Hash> &txs_ids, std::list<Transaction> &txs, std::list<crypto::Hash> &missed_txs, bool checkTxPool = false) override;
-    virtual bool getBlockByHash(const crypto::Hash &h, Block &blk) override;
-    virtual bool getBlockHeight(const crypto::Hash &blockId, uint32_t &blockHeight) override;
+    bool getBlockByHash(const crypto::Hash &h, Block &blk) override;
+    bool getBlockHeight(const crypto::Hash &blockId, uint32_t &blockHeight) override;
     //void get_all_known_block_ids(std::list<crypto::Hash> &main, std::list<crypto::Hash> &alt, std::list<crypto::Hash> &invalid);
 
     bool get_alternative_blocks(std::list<Block> &blocks);
@@ -122,26 +122,26 @@ namespace cn {
     size_t get_pool_transactions_count();
     size_t get_blockchain_total_transactions();
     //bool get_outs(uint64_t amount, std::list<crypto::PublicKey>& pkeys);
-    virtual std::vector<crypto::Hash> findBlockchainSupplement(const std::vector<crypto::Hash> &remoteBlockIds, size_t maxCount,
+    std::vector<crypto::Hash> findBlockchainSupplement(const std::vector<crypto::Hash> &remoteBlockIds, size_t maxCount,
                                                                uint32_t &totalBlockCount, uint32_t &startBlockIndex) override;
     bool get_stat_info(core_stat_info &st_inf) override;
 
-    virtual bool get_tx_outputs_gindexs(const crypto::Hash &tx_id, std::vector<uint32_t> &indexs) override;
+    bool get_tx_outputs_gindexs(const crypto::Hash &tx_id, std::vector<uint32_t> &indexs) override;
     crypto::Hash get_tail_id();
-    virtual bool get_random_outs_for_amounts(const COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS_request &req, COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS_response &res) override;
+    bool get_random_outs_for_amounts(const COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS_request &req, COMMAND_RPC_GET_RANDOM_OUTPUTS_FOR_AMOUNTS_response &res) override;
     void pause_mining() override;
     void update_block_template_and_resume_mining() override;
     //Blockchain& get_blockchain_storage(){return m_blockchain;}
     //debug functions
     void print_blockchain(uint32_t start_index, uint32_t end_index);
     void print_blockchain_index();
-    std::string print_pool(bool short_format);
+    const std::string print_pool(bool short_format);
     void print_blockchain_outs(const std::string &file);
-    virtual bool getPoolChanges(const crypto::Hash &tailBlockId, const std::vector<crypto::Hash> &knownTxsIds,
+    bool getPoolChanges(const crypto::Hash &tailBlockId, const std::vector<crypto::Hash> &knownTxsIds,
                                 std::vector<Transaction> &addedTxs, std::vector<crypto::Hash> &deletedTxsIds) override;
-    virtual bool getPoolChangesLite(const crypto::Hash &tailBlockId, const std::vector<crypto::Hash> &knownTxsIds,
+    bool getPoolChangesLite(const crypto::Hash &tailBlockId, const std::vector<crypto::Hash> &knownTxsIds,
                                     std::vector<TransactionPrefixInfo> &addedTxs, std::vector<crypto::Hash> &deletedTxsIds) override;
-    virtual void getPoolChanges(const std::vector<crypto::Hash> &knownTxsIds, std::vector<Transaction> &addedTxs,
+    void getPoolChanges(const std::vector<crypto::Hash> &knownTxsIds, std::vector<Transaction> &addedTxs,
                                 std::vector<crypto::Hash> &deletedTxsIds) override;
 
     uint64_t getNextBlockDifficulty();
@@ -170,8 +170,8 @@ namespace cn {
     bool handle_command_line(const boost::program_options::variables_map &vm);
     bool on_update_blocktemplate_interval();
     bool check_tx_inputs_keyimages_diff(const Transaction &tx);
-    virtual void blockchainUpdated() override;
-    virtual void txDeletedFromPool() override;
+    void blockchainUpdated() override;
+    void txDeletedFromPool() override;
     void poolUpdated();
 
     bool findStartAndFullOffsets(const std::vector<crypto::Hash> &knownBlockIds, uint64_t timestamp, uint32_t &startOffset, uint32_t &startFullOffset);

--- a/src/CryptoNoteCore/CoreConfig.cpp
+++ b/src/CryptoNoteCore/CoreConfig.cpp
@@ -22,6 +22,4 @@ void CoreConfig::init(const boost::program_options::variables_map& options) {
   }
 }
 
-void CoreConfig::initOptions(boost::program_options::options_description& desc) {
-}
 } //namespace cn

--- a/src/CryptoNoteCore/CryptoNoteBasicImpl.cpp
+++ b/src/CryptoNoteCore/CryptoNoteBasicImpl.cpp
@@ -53,6 +53,9 @@ namespace cn {
   std::string getAccountAddressAsStr(uint64_t prefix, const AccountPublicAddress& adr) {
     BinaryArray ba;
     bool r = toBinaryArray(adr, ba);
+    if (!r)
+      return 0;
+
     assert(r);
     return tools::base_58::encode_addr(prefix, common::asString(ba));
   }

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.cpp
@@ -80,7 +80,7 @@ bool constructTransaction(
   const std::vector<TransactionDestinationEntry>& destinations,
   const std::vector<tx_message_entry>& messages,
   uint64_t ttl,
-  std::vector<uint8_t> extra,
+  const std::vector<uint8_t> extra,
   Transaction& tx,
   uint64_t unlock_time,
   logging::ILogger& log,
@@ -111,7 +111,7 @@ bool constructTransaction(
     summary_inputs_money += src_entr.amount;
 
     //KeyDerivation recv_derivation;
-    in_contexts.push_back(input_generation_context_data());
+    in_contexts.emplace_back(input_generation_context_data());
     KeyPair& in_ephemeral = in_contexts.back().in_ephemeral;
     KeyImage img;
     if (!generate_key_image_helper(sender_account_keys, src_entr.realTransactionPublicKey, src_entr.realOutputIndexInTransaction, in_ephemeral, img))
@@ -137,7 +137,7 @@ bool constructTransaction(
     }
 
     input_to_key.outputIndexes = absolute_output_offsets_to_relative(input_to_key.outputIndexes);
-    tx.inputs.push_back(input_to_key);
+    tx.inputs.emplace_back(input_to_key);
   }
 
   KeyPair txkey;
@@ -204,7 +204,7 @@ bool constructTransaction(
   for (size_t i = 0; i < messages.size(); i++) {
     const tx_message_entry &msg = messages[i];
     tx_extra_message tag;
-    if (!tag.encrypt(i, msg.message, msg.encrypt ? &msg.addr : NULL, txkey)) {
+    if (!tag.encrypt(i, msg.message, msg.encrypt ? &msg.addr : nullptr, txkey)) {
       return false;
     }
 
@@ -228,7 +228,7 @@ bool constructTransaction(
       keys_ptrs.push_back(&o.second);
     }
 
-    tx.signatures.push_back(std::vector<Signature>());
+    tx.signatures.emplace_back(std::vector<Signature>());
     std::vector<Signature>& sigs = tx.signatures.back();
     sigs.resize(src_entr.outputs.size());
     generate_ring_signature(tx_prefix_hash, boost::get<KeyInput>(tx.inputs[i]).keyImage, keys_ptrs,

--- a/src/CryptoNoteCore/CryptoNoteFormatUtils.h
+++ b/src/CryptoNoteCore/CryptoNoteFormatUtils.h
@@ -61,7 +61,7 @@ inline bool constructTransaction(
   const AccountKeys& sender_account_keys,
   const std::vector<TransactionSourceEntry>& sources,
   const std::vector<TransactionDestinationEntry>& destinations,
-  std::vector<uint8_t> extra, Transaction& tx, uint64_t unlock_time, logging::ILogger& log, crypto::SecretKey& transactionSK) {
+  const std::vector<uint8_t> extra, Transaction& tx, uint64_t unlock_time, logging::ILogger& log, crypto::SecretKey& transactionSK) {
 
   return constructTransaction(sender_account_keys, sources, destinations, std::vector<tx_message_entry>(), 0, extra, tx, unlock_time, log, transactionSK);
 }
@@ -81,7 +81,7 @@ bool get_block_longhash(crypto::cn_context &context, const Block& b, crypto::Has
 bool get_inputs_money_amount(const Transaction& tx, uint64_t& money);
 uint64_t get_outs_money_amount(const Transaction& tx);
 bool check_inputs_types_supported(const TransactionPrefix& tx);
-bool check_outs_valid(const TransactionPrefix& tx, std::string* error = 0);
+bool check_outs_valid(const TransactionPrefix& tx, std::string* error = nullptr);
 bool checkMultisignatureInputsDiff(const TransactionPrefix& tx);
 
 bool check_money_overflow(const TransactionPrefix& tx);

--- a/src/CryptoNoteCore/CryptoNoteSerialization.cpp
+++ b/src/CryptoNoteCore/CryptoNoteSerialization.cpp
@@ -337,9 +337,9 @@ void serialize(AccountKeys& keys, ISerializer& s) {
 }
 
 void doSerialize(TransactionExtraMergeMiningTag& tag, ISerializer& serializer) {
-  uint64_t depth = static_cast<uint64_t>(tag.depth);
+  auto depth = static_cast<uint64_t>(tag.depth);
   serializer(depth, "depth");
-  tag.depth = static_cast<size_t>(depth);
+  tag.depth = depth;
   serializer(tag.merkleRoot, "merkle_root");
 }
 

--- a/src/CryptoNoteCore/CryptoNoteTools.cpp
+++ b/src/CryptoNoteCore/CryptoNoteTools.cpp
@@ -15,7 +15,7 @@ bool toBinaryArray(const BinaryArray& object, BinaryArray& binaryArray) {
     BinaryOutputStreamSerializer serializer(stream);
     std::string oldBlob = common::asString(object);
     serializer(oldBlob, "");
-  } catch (std::exception&) {
+  } catch (const std::exception&) {
     return false;
   }
 
@@ -71,8 +71,8 @@ uint64_t getOutputAmount(const Transaction& transaction) {
 
 void decomposeAmount(uint64_t amount, uint64_t dustThreshold, std::vector<uint64_t>& decomposedAmounts) {
   decompose_amount_into_digits(amount, dustThreshold,
-    [&](uint64_t amount) {
-    decomposedAmounts.push_back(amount);
+    [&](uint64_t d_amount) {
+    decomposedAmounts.push_back(d_amount);
   },
     [&](uint64_t dust) {
     decomposedAmounts.push_back(dust);

--- a/src/CryptoNoteCore/CryptoNoteTools.h
+++ b/src/CryptoNoteCore/CryptoNoteTools.h
@@ -25,7 +25,7 @@ bool toBinaryArray(const T& object, BinaryArray& binaryArray) {
     ::common::VectorOutputStream stream(binaryArray);
     BinaryOutputStreamSerializer serializer(stream);
     serialize(const_cast<T&>(object), serializer);
-  } catch (std::exception&) {
+  } catch (const std::exception&) {
     return false;
   }
 
@@ -50,7 +50,7 @@ bool fromBinaryArray(T& object, const BinaryArray& binaryArray) {
     BinaryInputStreamSerializer serializer(stream);
     serialize(object, serializer);
     result = stream.endOfStream(); // check that all data was consumed
-  } catch (std::exception&) {
+  } catch (const std::exception&) {
     return result;
   }
 

--- a/src/CryptoNoteCore/Currency.h
+++ b/src/CryptoNoteCore/Currency.h
@@ -198,7 +198,6 @@ namespace cn
     bool generateGenesisBlock();
     uint64_t baseRewardFunction(uint64_t alreadyGeneratedCoins, uint32_t height) const;
 
-  private:
     uint64_t m_maxBlockHeight;
     size_t m_maxBlockBlobSize;
     size_t m_maxTxSize;
@@ -303,7 +302,7 @@ namespace cn
       return m_currency;
     }
 
-    Transaction generateGenesisTransaction();
+    const Transaction generateGenesisTransaction();
     //Transaction generateGenesisTransaction(const std::vector<AccountPublicAddress>& targets);
 
     CurrencyBuilder &maxBlockNumber(uint64_t val)
@@ -514,27 +513,27 @@ namespace cn
       return *this;
     }
 
-    CurrencyBuilder &upgradeHeightV2(uint64_t val)
+    CurrencyBuilder &upgradeHeightV2(uint32_t val)
     {
       m_currency.m_upgradeHeightV2 = val;
       return *this;
     }
-    CurrencyBuilder &upgradeHeightV3(uint64_t val)
+    CurrencyBuilder &upgradeHeightV3(uint32_t val)
     {
       m_currency.m_upgradeHeightV3 = val;
       return *this;
     }
-    CurrencyBuilder &upgradeHeightV6(uint64_t val)
+    CurrencyBuilder &upgradeHeightV6(uint32_t val)
     {
       m_currency.m_upgradeHeightV6 = val;
       return *this;
     }
-    CurrencyBuilder &upgradeHeightV7(uint64_t val)
+    CurrencyBuilder &upgradeHeightV7(uint32_t val)
     {
       m_currency.m_upgradeHeightV7 = val;
       return *this;
     }
-    CurrencyBuilder &upgradeHeightV8(uint64_t val)
+    CurrencyBuilder &upgradeHeightV8(uint32_t val)
     {
       m_currency.m_upgradeHeightV8 = val;
       return *this;

--- a/src/CryptoNoteCore/DepositIndex.cpp
+++ b/src/CryptoNoteCore/DepositIndex.cpp
@@ -92,7 +92,7 @@ auto DepositIndex::size() const -> DepositHeight {
 auto DepositIndex::upperBound(DepositHeight height) const -> IndexType::const_iterator {
   return std::upper_bound(
       index.cbegin(), index.cend(), height,
-      [] (DepositHeight height, const DepositIndexEntry& left) { return height < left.height; });
+      [] (DepositHeight d_height, const DepositIndexEntry& left) { return d_height < left.height; });
 }
 
 size_t DepositIndex::popBlocks(DepositHeight from) {
@@ -100,7 +100,7 @@ size_t DepositIndex::popBlocks(DepositHeight from) {
     return 0;
   }
 
-  IndexType::iterator it = index.begin();
+  auto it = index.begin();
   std::advance(it, std::distance(index.cbegin(), upperBound(from)));
   if (it != index.begin()) {
     --it;

--- a/src/CryptoNoteCore/Difficulty.cpp
+++ b/src/CryptoNoteCore/Difficulty.cpp
@@ -46,7 +46,11 @@ namespace cn {
   }
 
   bool check_hash(const crypto::Hash &hash, difficulty_type difficulty) {
-    uint64_t low, high, top, cur;
+    uint64_t low;
+    uint64_t high;
+    uint64_t top;
+    uint64_t cur;
+
     // First check the highest word, this will most likely fail for a random hash.
     mul(swap64le(((const uint64_t *) &hash)[3]), difficulty, top, high);
     if (high != 0) {

--- a/src/CryptoNoteCore/ITimeProvider.h
+++ b/src/CryptoNoteCore/ITimeProvider.h
@@ -16,7 +16,7 @@ namespace cn {
   };
 
   struct RealTimeProvider : public ITimeProvider {
-    virtual time_t now() override {
+    time_t now() override {
       return time(nullptr);
     }
   };

--- a/src/CryptoNoteCore/InvestmentIndex.cpp
+++ b/src/CryptoNoteCore/InvestmentIndex.cpp
@@ -92,7 +92,7 @@ auto InvestmentIndex::size() const -> DepositHeight {
 auto InvestmentIndex::upperBound(DepositHeight height) const -> IndexType::const_iterator {
   return std::upper_bound(
       index.cbegin(), index.cend(), height,
-      [] (DepositHeight height, const InvestmentIndexEntry& left) { return height < left.height; });
+      [] (DepositHeight d_height, const InvestmentIndexEntry& left) { return d_height < left.height; });
 }
 
 size_t InvestmentIndex::popBlocks(DepositHeight from) {
@@ -100,7 +100,7 @@ size_t InvestmentIndex::popBlocks(DepositHeight from) {
     return 0;
   }
 
-  IndexType::iterator it = index.begin();
+  auto it = index.begin();
   std::advance(it, std::distance(index.cbegin(), upperBound(from)));
   if (it != index.begin()) {
     --it;

--- a/src/CryptoNoteCore/Transaction.cpp
+++ b/src/CryptoNoteCore/Transaction.cpp
@@ -45,66 +45,65 @@ namespace cn {
     TransactionImpl(const cn::Transaction& tx);
   
     // ITransactionReader
-    virtual Hash getTransactionHash() const override;
-    virtual Hash getTransactionPrefixHash() const override;
-    virtual Hash getTransactionInputsHash() const override;
-    virtual PublicKey getTransactionPublicKey() const override;
-    virtual uint64_t getUnlockTime() const override;
-    virtual bool getPaymentId(Hash& hash) const override;
-    virtual bool getExtraNonce(BinaryArray& nonce) const override;
-    virtual BinaryArray getExtra() const override;
+    Hash getTransactionHash() const override;
+    Hash getTransactionPrefixHash() const override;
+    Hash getTransactionInputsHash() const override;
+    PublicKey getTransactionPublicKey() const override;
+    uint64_t getUnlockTime() const override;
+    bool getPaymentId(Hash& hash) const override;
+    bool getExtraNonce(BinaryArray& nonce) const override;
+    BinaryArray getExtra() const override;
 
     // inputs
-    virtual size_t getInputCount() const override;
-    virtual uint64_t getInputTotalAmount() const override;
-    virtual transaction_types::InputType getInputType(size_t index) const override;
-    virtual void getInput(size_t index, KeyInput& input) const override;
-    virtual void getInput(size_t index, MultisignatureInput& input) const override;
-    virtual std::vector<TransactionInput> getInputs() const override;
+    size_t getInputCount() const override;
+    uint64_t getInputTotalAmount() const override;
+    transaction_types::InputType getInputType(size_t index) const override;
+    void getInput(size_t index, KeyInput& input) const override;
+    void getInput(size_t index, MultisignatureInput& input) const override;
+    std::vector<TransactionInput> getInputs() const override;
 
     // outputs
-    virtual size_t getOutputCount() const override;
-    virtual uint64_t getOutputTotalAmount() const override;
-    virtual transaction_types::OutputType getOutputType(size_t index) const override;
-    virtual void getOutput(size_t index, KeyOutput& output, uint64_t& amount) const override;
-    virtual void getOutput(size_t index, MultisignatureOutput& output, uint64_t& amount) const override;
+    size_t getOutputCount() const override;
+    uint64_t getOutputTotalAmount() const override;
+    transaction_types::OutputType getOutputType(size_t index) const override;
+    void getOutput(size_t index, KeyOutput& output, uint64_t& amount) const override;
+    void getOutput(size_t index, MultisignatureOutput& output, uint64_t& amount) const override;
 
-    virtual size_t getRequiredSignaturesCount(size_t index) const override;
-    virtual bool findOutputsToAccount(const AccountPublicAddress& addr, const SecretKey& viewSecretKey, std::vector<uint32_t>& outs, uint64_t& outputAmount) const override;
+    size_t getRequiredSignaturesCount(size_t index) const override;
+    bool findOutputsToAccount(const AccountPublicAddress& addr, const SecretKey& viewSecretKey, std::vector<uint32_t>& outs, uint64_t& outputAmount) const override;
 
     // various checks
-    virtual bool validateInputs() const override;
-    virtual bool validateOutputs() const override;
-    virtual bool validateSignatures() const override;
+    bool validateInputs() const override;
+    bool validateOutputs() const override;
+    bool validateSignatures() const override;
 
     // get serialized transaction
-    virtual BinaryArray getTransactionData() const override;
+    BinaryArray getTransactionData() const override;
     TransactionPrefix getTransactionPrefix() const override;
     // ITransactionWriter
 
-    virtual void setUnlockTime(uint64_t unlockTime) override;
-    virtual void setPaymentId(const Hash& hash) override;
-    virtual void setExtraNonce(const BinaryArray& nonce) override;
-    virtual void appendExtra(const BinaryArray& extraData) override;
+    void setUnlockTime(uint64_t unlockTime) override;
+    void setPaymentId(const Hash& hash) override;
+    void setExtraNonce(const BinaryArray& nonce) override;
+    void appendExtra(const BinaryArray& extraData) override;
 
     // Inputs/Outputs 
-    virtual size_t addInput(const KeyInput& input) override;
-    virtual size_t addInput(const MultisignatureInput& input) override;
-    virtual size_t addInput(const AccountKeys& senderKeys, const transaction_types::InputKeyInfo& info, KeyPair& ephKeys) override;
+    size_t addInput(const KeyInput& input) override;
+    size_t addInput(const MultisignatureInput& input) override;
+    size_t addInput(const AccountKeys& senderKeys, const transaction_types::InputKeyInfo& info, KeyPair& ephKeys) override;
 
-    virtual size_t addOutput(uint64_t amount, const AccountPublicAddress& to) override;
-    virtual size_t addOutput(uint64_t amount, const std::vector<AccountPublicAddress>& to, uint32_t requiredSignatures, uint32_t term = 0) override;
-    virtual size_t addOutput(uint64_t amount, const KeyOutput& out) override;
-    virtual size_t addOutput(uint64_t amount, const MultisignatureOutput& out) override;
+    size_t addOutput(uint64_t amount, const AccountPublicAddress& to) override;
+    size_t addOutput(uint64_t amount, const std::vector<AccountPublicAddress>& to, uint8_t requiredSignatures, uint32_t term = 0) override;
+    size_t addOutput(uint64_t amount, const KeyOutput& out) override;
+    size_t addOutput(uint64_t amount, const MultisignatureOutput& out) override;
 
-    virtual void signInputKey(size_t input, const transaction_types::InputKeyInfo& info, const KeyPair& ephKeys) override;
-    virtual void signInputMultisignature(size_t input, const PublicKey& sourceTransactionKey, size_t outputIndex, const AccountKeys& accountKeys) override;
-    virtual void signInputMultisignature(size_t input, const KeyPair& ephemeralKeys) override;
-
+    void signInputKey(size_t input, const transaction_types::InputKeyInfo& info, const KeyPair& ephKeys) override;
+    void signInputMultisignature(size_t input, const PublicKey& sourceTransactionKey, size_t outputIndex, const AccountKeys& accountKeys) override;
+    void signInputMultisignature(size_t input, const KeyPair& ephemeralKeys) override;
 
     // secret key
-    virtual bool getTransactionSecretKey(SecretKey& key) const override;
-    virtual void setTransactionSecretKey(const SecretKey& key) override;
+    bool getTransactionSecretKey(SecretKey& key) const override;
+    void setTransactionSecretKey(const SecretKey& key) override;
 
   private:
 
@@ -266,7 +265,7 @@ namespace cn {
 
   size_t TransactionImpl::addInput(const MultisignatureInput& input) {
     checkIfSigning();
-    transaction.inputs.push_back(input);
+    transaction.inputs.emplace_back(input);
     transaction.version = TRANSACTION_VERSION_2;
     invalidateHash();
     return transaction.inputs.size() - 1;
@@ -284,7 +283,7 @@ namespace cn {
     return transaction.outputs.size() - 1;
   }
 
-  size_t TransactionImpl::addOutput(uint64_t amount, const std::vector<AccountPublicAddress>& to, uint32_t requiredSignatures, uint32_t term) {
+  size_t TransactionImpl::addOutput(uint64_t amount, const std::vector<AccountPublicAddress>& to, uint8_t requiredSignatures, uint32_t term) {
     checkIfSigning();
 
     const auto& txKey = txSecretKey();

--- a/src/CryptoNoteCore/TransactionExtra.cpp
+++ b/src/CryptoNoteCore/TransactionExtra.cpp
@@ -56,7 +56,7 @@ namespace cn
             return false;
           }
 
-          transactionExtraFields.push_back(TransactionExtraPadding{size});
+          transactionExtraFields.emplace_back(TransactionExtraPadding{size});
           break;
         }
 
@@ -64,7 +64,7 @@ namespace cn
         {
           TransactionExtraPublicKey extraPk;
           ar(extraPk.publicKey, "public_key");
-          transactionExtraFields.push_back(extraPk);
+          transactionExtraFields.emplace_back(extraPk);
           break;
         }
 
@@ -78,7 +78,7 @@ namespace cn
             read(iss, extraNonce.nonce.data(), extraNonce.nonce.size());
           }
 
-          transactionExtraFields.push_back(extraNonce);
+          transactionExtraFields.emplace_back(extraNonce);
           break;
         }
 
@@ -86,7 +86,7 @@ namespace cn
         {
           TransactionExtraMergeMiningTag mmTag;
           ar(mmTag, "mm_tag");
-          transactionExtraFields.push_back(mmTag);
+          transactionExtraFields.emplace_back(mmTag);
           break;
         }
 
@@ -94,7 +94,7 @@ namespace cn
         {
           tx_extra_message message;
           ar(message.data, "message");
-          transactionExtraFields.push_back(message);
+          transactionExtraFields.emplace_back(message);
           break;
         }
 
@@ -104,13 +104,13 @@ namespace cn
           readVarint(iss, size);
           TransactionExtraTTL ttl;
           readVarint(iss, ttl.ttl);
-          transactionExtraFields.push_back(ttl);
+          transactionExtraFields.emplace_back(ttl);
           break;
         }
         }
       }
     }
-    catch (std::exception &)
+    catch (const std::exception &)
     {
       return false;
     }
@@ -293,7 +293,7 @@ namespace cn
   {
     extra_nonce.clear();
     extra_nonce.push_back(TX_EXTRA_NONCE_PAYMENT_ID);
-    const uint8_t *payment_id_ptr = reinterpret_cast<const uint8_t *>(&payment_id);
+    const auto *payment_id_ptr = reinterpret_cast<const uint8_t *>(&payment_id);
     std::copy(payment_id_ptr, payment_id_ptr + sizeof(payment_id), std::back_inserter(extra_nonce));
   }
 
@@ -356,7 +356,7 @@ namespace cn
     return true;
   }
 
-#define TX_EXTRA_MESSAGE_CHECKSUM_SIZE 4
+const uint8_t TX_EXTRA_MESSAGE_CHECKSUM_SIZE = 4;
 
 #pragma pack(push, 1)
   struct message_key_data
@@ -384,7 +384,7 @@ namespace cn
       key_data.magic1 = 0x80;
       key_data.magic2 = 0;
       Hash h = cn_fast_hash(&key_data, sizeof(message_key_data));
-      uint64_t nonce = SWAP64LE(index);
+      auto nonce = SWAP64LE(index);
       chacha8(buf.get(), mlen, reinterpret_cast<uint8_t *>(&h), reinterpret_cast<uint8_t *>(&nonce), buf.get());
     }
     data.assign(buf.get(), mlen);
@@ -412,7 +412,7 @@ namespace cn
       key_data.magic1 = 0x80;
       key_data.magic2 = 0;
       Hash h = cn_fast_hash(&key_data, sizeof(message_key_data));
-      uint64_t nonce = SWAP64LE(index);
+      auto nonce = SWAP64LE(index);
       chacha8(data.data(), mlen, reinterpret_cast<uint8_t *>(&h), reinterpret_cast<uint8_t *>(&nonce), ptr.get());
       buf = ptr.get();
     }

--- a/src/CryptoNoteCore/TransactionExtra.h
+++ b/src/CryptoNoteCore/TransactionExtra.h
@@ -14,17 +14,17 @@
 
 #include <CryptoNote.h>
 
-#define TX_EXTRA_PADDING_MAX_COUNT          255
-#define TX_EXTRA_NONCE_MAX_COUNT            255
+const uint8_t TX_EXTRA_PADDING_MAX_COUNT =  255;
+const uint8_t TX_EXTRA_NONCE_MAX_COUNT   =  255;
 
-#define TX_EXTRA_TAG_PADDING                0x00
-#define TX_EXTRA_TAG_PUBKEY                 0x01
-#define TX_EXTRA_NONCE                      0x02
-#define TX_EXTRA_MERGE_MINING_TAG           0x03
-#define TX_EXTRA_MESSAGE_TAG                0x04
-#define TX_EXTRA_TTL                        0x05
+const uint8_t TX_EXTRA_TAG_PADDING       =  0x00;
+const uint8_t TX_EXTRA_TAG_PUBKEY        =  0x01;
+const uint8_t TX_EXTRA_NONCE             =  0x02;
+const uint8_t TX_EXTRA_MERGE_MINING_TAG  =  0x03;
+const uint8_t TX_EXTRA_MESSAGE_TAG       =  0x04;
+const uint8_t TX_EXTRA_TTL               =  0x05;
 
-#define TX_EXTRA_NONCE_PAYMENT_ID           0x00
+const uint8_t TX_EXTRA_NONCE_PAYMENT_ID  =  0x00;
 
 namespace cn {
 

--- a/src/CryptoNoteCore/TransactionPool.h
+++ b/src/CryptoNoteCore/TransactionPool.h
@@ -91,14 +91,11 @@ namespace cn {
     //gets tx and remove it from pool
     bool take_tx(const crypto::Hash &id, Transaction &tx, size_t& blobSize, uint64_t& fee);
 
-    bool on_blockchain_inc(uint64_t new_block_height, const crypto::Hash& top_block_id);
-    bool on_blockchain_dec(uint64_t new_block_height, const crypto::Hash& top_block_id);
-
     void lock() const;
     void unlock() const;
     std::unique_lock<std::recursive_mutex> obtainGuard() const;
 
-    bool fill_block_template(Block &bl, size_t median_size, size_t maxCumulativeSize, uint64_t already_generated_coins, size_t &total_size, uint64_t &fee, uint32_t& height);
+    bool fill_block_template(Block &bl, size_t median_size, size_t maxCumulativeSize, uint64_t already_generated_coins, size_t &total_size, uint64_t &fee, const uint32_t& height);
 
     void get_transactions(std::list<Transaction>& txs) const;
     void get_difference(const std::vector<crypto::Hash>& known_tx_ids, std::vector<crypto::Hash>& new_tx_ids, std::vector<crypto::Hash>& deleted_tx_ids) const;
@@ -149,8 +146,10 @@ namespace cn {
         // price(lhs) > price(rhs) -->
         // lhs.fee / lhs.blobSize > rhs.fee / rhs.blobSize -->
         // lhs.fee * rhs.blobSize > rhs.fee * lhs.blobSize
-        uint64_t lhs_hi, lhs_lo = mul128(lhs.fee, rhs.blobSize, &lhs_hi);
-        uint64_t rhs_hi, rhs_lo = mul128(rhs.fee, lhs.blobSize, &rhs_hi);
+        uint64_t lhs_hi;
+        uint64_t lhs_lo = mul128(lhs.fee, rhs.blobSize, &lhs_hi);
+        uint64_t rhs_hi;
+        uint64_t rhs_lo = mul128(rhs.fee, lhs.blobSize, &rhs_hi);
 
         return
           // prefer more profitable transactions

--- a/src/CryptoNoteCore/TransactionPrefixImpl.cpp
+++ b/src/CryptoNoteCore/TransactionPrefixImpl.cpp
@@ -25,45 +25,45 @@ public:
 
   virtual ~TransactionPrefixImpl() { }
 
-  virtual Hash getTransactionHash() const override;
-  virtual Hash getTransactionPrefixHash() const override;
-  virtual Hash getTransactionInputsHash() const override;
-  virtual PublicKey getTransactionPublicKey() const override;
-  virtual uint64_t getUnlockTime() const override;
+  Hash getTransactionHash() const override;
+  Hash getTransactionPrefixHash() const override;
+  Hash getTransactionInputsHash() const override;
+  PublicKey getTransactionPublicKey() const override;
+  uint64_t getUnlockTime() const override;
 
   // extra
-  virtual bool getPaymentId(Hash& paymentId) const override;
-  virtual bool getExtraNonce(BinaryArray& nonce) const override;
-  virtual BinaryArray getExtra() const override;
+  bool getPaymentId(Hash& paymentId) const override;
+  bool getExtraNonce(BinaryArray& nonce) const override;
+  BinaryArray getExtra() const override;
 
   // inputs
-  virtual size_t getInputCount() const override;
-  virtual uint64_t getInputTotalAmount() const override;
-  virtual transaction_types::InputType getInputType(size_t index) const override;
-  virtual void getInput(size_t index, KeyInput& input) const override;
-  virtual void getInput(size_t index, MultisignatureInput& input) const override;
-  virtual std::vector<TransactionInput> getInputs() const override;
+  size_t getInputCount() const override;
+  uint64_t getInputTotalAmount() const override;
+  transaction_types::InputType getInputType(size_t index) const override;
+  void getInput(size_t index, KeyInput& input) const override;
+  void getInput(size_t index, MultisignatureInput& input) const override;
+  std::vector<TransactionInput> getInputs() const override;
 
   // outputs
-  virtual size_t getOutputCount() const override;
-  virtual uint64_t getOutputTotalAmount() const override;
-  virtual transaction_types::OutputType getOutputType(size_t index) const override;
-  virtual void getOutput(size_t index, KeyOutput& output, uint64_t& amount) const override;
-  virtual void getOutput(size_t index, MultisignatureOutput& output, uint64_t& amount) const override;
+  size_t getOutputCount() const override;
+  uint64_t getOutputTotalAmount() const override;
+  transaction_types::OutputType getOutputType(size_t index) const override;
+  void getOutput(size_t index, KeyOutput& output, uint64_t& amount) const override;
+  void getOutput(size_t index, MultisignatureOutput& output, uint64_t& amount) const override;
 
   // signatures
-  virtual size_t getRequiredSignaturesCount(size_t inputIndex) const override;
-  virtual bool findOutputsToAccount(const AccountPublicAddress& addr, const SecretKey& viewSecretKey, std::vector<uint32_t>& outs, uint64_t& outputAmount) const override;
+  size_t getRequiredSignaturesCount(size_t inputIndex) const override;
+  bool findOutputsToAccount(const AccountPublicAddress& addr, const SecretKey& viewSecretKey, std::vector<uint32_t>& outs, uint64_t& outputAmount) const override;
 
   // various checks
-  virtual bool validateInputs() const override;
-  virtual bool validateOutputs() const override;
-  virtual bool validateSignatures() const override;
+  bool validateInputs() const override;
+  bool validateOutputs() const override;
+  bool validateSignatures() const override;
 
   // serialized transaction
-  virtual BinaryArray getTransactionData() const override;
-  virtual TransactionPrefix getTransactionPrefix() const override;
-  virtual bool getTransactionSecretKey(SecretKey& key) const override;
+  BinaryArray getTransactionData() const override;
+  TransactionPrefix getTransactionPrefix() const override;
+  bool getTransactionSecretKey(SecretKey& key) const override;
 
 private:
   TransactionPrefix m_txPrefix;

--- a/src/CryptoNoteCore/TransactionUtils.cpp
+++ b/src/CryptoNoteCore/TransactionUtils.cpp
@@ -20,9 +20,8 @@ namespace cn {
 bool checkInputsKeyimagesDiff(const cn::TransactionPrefix& tx) {
   std::unordered_set<crypto::KeyImage> ki;
   for (const auto& in : tx.inputs) {
-    if (in.type() == typeid(KeyInput)) {
-      if (!ki.insert(boost::get<KeyInput>(in).keyImage).second)
-        return false;
+    if (in.type() == typeid(KeyInput) && !ki.insert(boost::get<KeyInput>(in).keyImage).second) {
+      return false;
     }
   }
   return true;

--- a/src/CryptoNoteCore/UpgradeDetector.h
+++ b/src/CryptoNoteCore/UpgradeDetector.h
@@ -69,7 +69,7 @@ namespace cn {
           if (m_blockchain.back().bl.majorVersion >= m_targetVersion) {
             logger(logging::ERROR, logging::BRIGHT_RED) << "Internal error: block at height " << (m_blockchain.size() - 1) <<
               " has invalid version " << static_cast<int>(m_blockchain.back().bl.majorVersion) <<
-              ", expected " << static_cast<int>(m_targetVersion - 1) << " or less";
+              ", expected " << m_targetVersion - 1 << " or less";
             return false;
           }
         } else {
@@ -186,7 +186,6 @@ namespace cn {
       return voteCounter;
     }
 
-  private:
     uint32_t findVotingCompleteHeight(uint32_t probableUpgradeHeight) {
       assert(m_currency.upgradeHeight(m_targetVersion) == UNDEF_HEIGHT);
 

--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -184,7 +184,7 @@ int main(int argc, char* argv[])
    //command_line::add_arg(desc_cmd_sett, arg_genesis_block_reward_address);
 
    RpcServerConfig::initOptions(desc_cmd_sett);
-   CoreConfig::initOptions(desc_cmd_sett);
+   //CoreConfig::initOptions(desc_cmd_sett);
    NetNodeConfig::initOptions(desc_cmd_sett);
    MinerConfig::initOptions(desc_cmd_sett);
 

--- a/src/Daemon/Daemon.cpp
+++ b/src/Daemon/Daemon.cpp
@@ -61,55 +61,15 @@ void print_genesis_tx_hex() {
   cn::Transaction tx = cn::CurrencyBuilder(logger).generateGenesisTransaction();
   cn::BinaryArray txb = cn::toBinaryArray(tx);
   std::string tx_hex = common::toHex(txb);
+  LoggerManager gen_m;
+  LoggerRef gen_log(gen_m, "[Genesis]");
 
-  std::cout << "Insert this line into your coin configuration file as is: " << std::endl;
-  std::cout << "const char GENESIS_COINBASE_TX_HEX[] = \"" << tx_hex << "\";" << std::endl;
+  /* Someone who knows what to do with this will find it helpful,
+     if not, it't not our job to teach. */
+  gen_log(INFO) << "Random genesis hex: " << tx_hex;
 
   return;
 }
-
-// void print_genesis_tx_hex(const po::variables_map& vm) {
-  // std::vector<cn::AccountPublicAddress> targets;
- //  auto genesis_block_reward_addresses = command_line::get_arg(vm, arg_genesis_block_reward_address);
-
-//   logging::ConsoleLogger logger;
-//   cn::CurrencyBuilder currencyBuilder(logger);
-
- //  cn::Currency currency = currencyBuilder.currency();
-
- //  for (const auto& address_string : genesis_block_reward_addresses) {
- //     cn::AccountPublicAddress address;
-   //  if (!currency.parseAccountAddressString(address_string, address)) {
-   //    std::cout << "Failed to parse address: " << address_string << std::endl;
-   //    return;
-  //   }
- //	//Print GENESIS_BLOCK_REWARD Mined Address
- //	std::cout << "Your SDN Pre-mined Address String is:  " << address_string << std::endl;
- //    targets.emplace_back(std::move(address));
-//   }
-
- //  if (targets.empty()) {
- //    if (cn::parameters::GENESIS_BLOCK_REWARD > 0) {
- //      std::cout << "Error: genesis block reward addresses are not defined" << std::endl;
- //    } else {
-
- //	  cn::Transaction tx = cn::CurrencyBuilder(logger).generateGenesisTransaction();
- //	  cn::BinaryArray txb = cn::toBinaryArray(tx);
- //	  std::string tx_hex = common::toHex(txb);
-
-// 	  std::cout << "Insert this line into your coin configuration file as is: " << std::endl;
- //	  std::cout << "const char GENESIS_COINBASE_TX_HEX[] = \"" << tx_hex << "\";" << std::endl;
- //	}
-//   } else {
- //	cn::Transaction tx = cn::CurrencyBuilder(logger).generateGenesisTransaction(targets);
- //	cn::BinaryArray txb = cn::toBinaryArray(tx);
- //	std::string tx_hex = common::toHex(txb);
-
- //	std::cout << "Modify this line into your concealX configuration file as is:  " << std::endl;
- //	std::cout << "const char GENESIS_COINBASE_TX_HEX[] = \"" << tx_hex << "\";" << std::endl;
-//   }
-//   return;
-// }
 
 JsonValue buildLoggerConfiguration(Level level, const std::string& logfile) {
   JsonValue loggerConfiguration(JsonValue::OBJECT);
@@ -166,72 +126,75 @@ int main(int argc, char* argv[])
     po::options_description desc_cmd_only("Command line options");
     po::options_description desc_cmd_sett("Command line options and settings options");
 
-   desc_cmd_sett.add_options()("enable-blockchain-indexes,i", po::bool_switch()->default_value(false), "Enable blockchain indexes");
-   desc_cmd_sett.add_options()("enable-autosave,a", po::bool_switch()->default_value(false), "Enable blockchain autosave every 720 blocks");
+    desc_cmd_sett.add_options()("enable-blockchain-indexes,i", po::bool_switch()->default_value(false), "Enable blockchain indexes");
+    desc_cmd_sett.add_options()("enable-autosave,a", po::bool_switch()->default_value(false), "Enable blockchain autosave every 720 blocks");
 
-   command_line::add_arg(desc_cmd_only, command_line::arg_help);
-   command_line::add_arg(desc_cmd_only, command_line::arg_version);
-   command_line::add_arg(desc_cmd_only, arg_os_version);
-   command_line::add_arg(desc_cmd_only, command_line::arg_data_dir, tools::getDefaultDataDirectory());
-   command_line::add_arg(desc_cmd_only, arg_config_file);
-   command_line::add_arg(desc_cmd_sett, arg_set_fee_address);
-   command_line::add_arg(desc_cmd_sett, arg_log_file);
-   command_line::add_arg(desc_cmd_sett, arg_log_level);
-   command_line::add_arg(desc_cmd_sett, arg_console);
-   command_line::add_arg(desc_cmd_sett, arg_set_view_key);
-   command_line::add_arg(desc_cmd_sett, arg_testnet_on);
-   command_line::add_arg(desc_cmd_sett, arg_print_genesis_tx);
-   //command_line::add_arg(desc_cmd_sett, arg_genesis_block_reward_address);
+    command_line::add_arg(desc_cmd_only, command_line::arg_help);
+    command_line::add_arg(desc_cmd_only, command_line::arg_version);
+    command_line::add_arg(desc_cmd_only, arg_os_version);
+    command_line::add_arg(desc_cmd_only, command_line::arg_data_dir, tools::getDefaultDataDirectory());
+    command_line::add_arg(desc_cmd_only, arg_config_file);
+    command_line::add_arg(desc_cmd_sett, arg_set_fee_address);
+    command_line::add_arg(desc_cmd_sett, arg_log_file);
+    command_line::add_arg(desc_cmd_sett, arg_log_level);
+    command_line::add_arg(desc_cmd_sett, arg_console);
+    command_line::add_arg(desc_cmd_sett, arg_set_view_key);
+    command_line::add_arg(desc_cmd_sett, arg_testnet_on);
+    command_line::add_arg(desc_cmd_sett, arg_print_genesis_tx);
+    //command_line::add_arg(desc_cmd_sett, arg_genesis_block_reward_address);
 
-   RpcServerConfig::initOptions(desc_cmd_sett);
-   //CoreConfig::initOptions(desc_cmd_sett);
-   NetNodeConfig::initOptions(desc_cmd_sett);
-   MinerConfig::initOptions(desc_cmd_sett);
+    RpcServerConfig::initOptions(desc_cmd_sett);
+    //CoreConfig::initOptions(desc_cmd_sett);
+    NetNodeConfig::initOptions(desc_cmd_sett);
+    MinerConfig::initOptions(desc_cmd_sett);
 
-   po::options_description desc_options("Allowed options");
-   desc_options.add(desc_cmd_only).add(desc_cmd_sett);
+    po::options_description desc_options("Allowed options");
+    desc_options.add(desc_cmd_only).add(desc_cmd_sett);
 
-   po::variables_map vm;
-   bool r = command_line::handle_error_helper(desc_options, [&]() {
-     po::store(po::parse_command_line(argc, argv, desc_options), vm);
+    po::variables_map vm;
+    bool r = command_line::handle_error_helper(desc_options, [&]() {
+      po::store(po::parse_command_line(argc, argv, desc_options), vm);
 
-     if (command_line::get_arg(vm, command_line::arg_help))
-     {
-       std::cout << cn::CRYPTONOTE_NAME << " v" << PROJECT_VERSION_LONG << ENDL << ENDL;
-       std::cout << desc_options << std::endl;
-       return false;
-     }
+      if (command_line::get_arg(vm, command_line::arg_help))
+      {
+        LoggerManager options_m;
+        LoggerRef options_log(options_m, "[Options]");
 
-     if (command_line::get_arg(vm, arg_print_genesis_tx))
-     {
-       //print_genesis_tx_hex(vm);
-       print_genesis_tx_hex();
-       return false;
-     }
+        options_log(INFO, BRIGHT_YELLOW) << cn::CRYPTONOTE_NAME << " v" << PROJECT_VERSION << " (" << PROJECT_VERSION_BUILD_NO << ")\n\n";
+        options_log(INFO) << desc_options;
 
-     std::string data_dir = command_line::get_arg(vm, command_line::arg_data_dir);
-     std::string config = command_line::get_arg(vm, arg_config_file);
+        return false;
+      }
 
-     boost::filesystem::path data_dir_path(data_dir);
-     boost::filesystem::path config_path(config);
-     if (!config_path.has_parent_path())
-     {
-       config_path = data_dir_path / config_path;
-     }
+      if (command_line::get_arg(vm, arg_print_genesis_tx))
+      {
+        print_genesis_tx_hex();
+        return false;
+      }
 
-     boost::system::error_code ec;
-     if (boost::filesystem::exists(config_path, ec))
-     {
-       po::store(po::parse_config_file<char>(config_path.string<std::string>().c_str(), desc_cmd_sett), vm);
-     }
+      std::string data_dir = command_line::get_arg(vm, command_line::arg_data_dir);
+      std::string config = command_line::get_arg(vm, arg_config_file);
 
-     po::notify(vm);
-     return true;
-   });
+      boost::filesystem::path data_dir_path(data_dir);
+      boost::filesystem::path config_path(config);
+      if (!config_path.has_parent_path())
+      {
+        config_path = data_dir_path / config_path;
+      }
 
-   if (!r)
-   {
-     return 1;
+      boost::system::error_code ec;
+      if (boost::filesystem::exists(config_path, ec))
+      {
+        po::store(po::parse_config_file<char>(config_path.string<std::string>().c_str(), desc_cmd_sett), vm);
+      }
+
+      po::notify(vm);
+      return true;
+    });
+
+    if (!r)
+    {
+      return 1;
     }
 
     auto modulePath = common::NativePathToGeneric(argv[0]);
@@ -245,7 +208,7 @@ int main(int argc, char* argv[])
       }
     }
 
-    Level cfgLogLevel = static_cast<Level>(static_cast<int>(logging::ERROR) + command_line::get_arg(vm, arg_log_level));
+    auto cfgLogLevel = static_cast<Level>(static_cast<int>(logging::ERROR) + command_line::get_arg(vm, arg_log_level));
 
     // configure logging
     logManager.configure(buildLoggerConfiguration(cfgLogLevel, cfgLogFile));
@@ -269,8 +232,8 @@ int main(int argc, char* argv[])
 
     try {
       currencyBuilder.currency();
-    } catch (std::exception&) {
-      std::cout << "GENESIS_COINBASE_TX_HEX constant has an incorrect value. Please launch: " << cn::CRYPTONOTE_NAME << "d --" << arg_print_genesis_tx.name;
+    } catch (const std::exception&) {
+      std::cerr << "GENESIS_COINBASE_TX_HEX constant has an incorrect value. Please launch: " << cn::CRYPTONOTE_NAME << "d --" << arg_print_genesis_tx.name;
       return 1;
     }
 
@@ -381,8 +344,8 @@ int main(int argc, char* argv[])
     logger(INFO) << "Deinitializing p2p...";
     p2psrv.deinit();
 
-    ccore.set_cryptonote_protocol(NULL);
-    cprotocol.set_p2p_endpoint(NULL);
+    ccore.set_cryptonote_protocol(nullptr);
+    cprotocol.set_p2p_endpoint(nullptr);
 
   } catch (const std::exception& e) {
     logger(ERROR, BRIGHT_RED) << "Exception: " << e.what();
@@ -397,12 +360,12 @@ bool command_line_preprocessor(const boost::program_options::variables_map &vm, 
   bool exit = false;
 
   if (command_line::get_arg(vm, command_line::arg_version)) {
-    std::cout << cn::CRYPTONOTE_NAME << " v" << PROJECT_VERSION_LONG << ENDL;
+    logger(INFO) << cn::CRYPTONOTE_NAME << " v" << PROJECT_VERSION_LONG;
     exit = true;
   }
 
   if (command_line::get_arg(vm, arg_os_version)) {
-    std::cout << "OS: " << tools::get_os_version_string() << ENDL;
+    logger(INFO) << "OS: " << tools::get_os_version_string();
     exit = true;
   }
 

--- a/src/Daemon/DaemonCommandsHandler.cpp
+++ b/src/Daemon/DaemonCommandsHandler.cpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2011-2017 The Cryptonote developers
 // Copyright (c) 2017-2018 The Circle Foundation & Conceal Devs
-// Copyright (c) 2018-2021 Conceal Network & Conceal Devs
+// Copyright (c) 2018-2022 Conceal Network & Conceal Devs
 //
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -20,7 +20,11 @@ namespace
   template <typename T>
   static bool print_as_json(const T &obj)
   {
-    std::cout << cn::storeToJson(obj) << ENDL;
+    logging::LoggerManager json_m;
+    logging::LoggerRef json_log(json_m, "[JSON]");
+
+    json_log() << " " << cn::storeToJson(obj);
+
     return true;
   }
 } // namespace
@@ -47,7 +51,7 @@ DaemonCommandsHandler::DaemonCommandsHandler(cn::core &core, cn::NodeServer &srv
 }
 
 //--------------------------------------------------------------------------------
-std::string DaemonCommandsHandler::get_commands_str()
+const std::string DaemonCommandsHandler::get_commands_str()
 {
   std::stringstream ss;
   ss << cn::CRYPTONOTE_NAME << " v" << PROJECT_VERSION_LONG << ENDL;
@@ -62,31 +66,63 @@ std::string DaemonCommandsHandler::get_commands_str()
 //--------------------------------------------------------------------------------
 bool DaemonCommandsHandler::exit(const std::vector<std::string> &args)
 {
+  if (!args.empty())
+  {
+    logger(logging::ERROR) << "Usage: \"exit\"";
+    return true;
+  }
+  
   m_consoleHandler.requestStop();
   m_srv.sendStopSignal();
+
   return true;
 }
 
 //--------------------------------------------------------------------------------
 bool DaemonCommandsHandler::help(const std::vector<std::string> &args)
 {
-  std::cout << get_commands_str() << ENDL;
+  if (!args.empty())
+  {
+    logger(logging::ERROR) << "Usage: \"help\"";
+    return true;
+  }
+
+  logger(logging::INFO) << get_commands_str();
   return true;
 }
 //--------------------------------------------------------------------------------
 bool DaemonCommandsHandler::save(const std::vector<std::string> &args)
 {
+  if (!args.empty())
+  {
+    logger(logging::ERROR) << "Usage: \"save\"";
+    return true;
+  }
+
   return m_core.saveBlockchain();
 }
 //--------------------------------------------------------------------------------
 bool DaemonCommandsHandler::print_pl(const std::vector<std::string> &args)
 {
+  if (!args.empty())
+  {
+    logger(logging::ERROR) << "Usage: \"print_pl\"";
+    return true;
+  }
+
   m_srv.log_peerlist();
+
   return true;
 }
 //--------------------------------------------------------------------------------
 bool DaemonCommandsHandler::show_hr(const std::vector<std::string> &args)
 {
+  if (!args.empty())
+  {
+    logger(logging::ERROR) << "Usage: \"show_hr\"";
+    return true;
+  }
+
   if (!m_core.get_miner().is_mining())
   {
     std::cout << "Mining is not started. You need to start mining before you can see hash rate." << ENDL;
@@ -95,29 +131,47 @@ bool DaemonCommandsHandler::show_hr(const std::vector<std::string> &args)
   {
     m_core.get_miner().do_print_hashrate(true);
   }
+
   return true;
 }
 //--------------------------------------------------------------------------------
 bool DaemonCommandsHandler::hide_hr(const std::vector<std::string> &args)
 {
+  if (!args.empty())
+  {
+    logger(logging::ERROR) << "Usage: \"hide_hr\"";
+    return true;
+  }
+
   m_core.get_miner().do_print_hashrate(false);
+
   return true;
 }
 //--------------------------------------------------------------------------------
 bool DaemonCommandsHandler::print_bc_outs(const std::vector<std::string> &args)
 {
+  // TODO implement this command
   if (args.size() != 1)
   {
     std::cout << "need file path as parameter" << ENDL;
     return true;
   }
+
   m_core.print_blockchain_outs(args[0]);
+
   return true;
 }
 //--------------------------------------------------------------------------------
 bool DaemonCommandsHandler::print_cn(const std::vector<std::string> &args)
 {
+  if (!args.empty())
+  {
+    logger(logging::ERROR) << "Usage: \"print_cn\"";
+    return true;
+  }
+
   m_srv.get_payload_object().log_connections();
+
   return true;
 }
 //--------------------------------------------------------------------------------
@@ -167,7 +221,15 @@ bool DaemonCommandsHandler::print_bc(const std::vector<std::string> &args)
 //--------------------------------------------------------------------------------
 bool DaemonCommandsHandler::print_bci(const std::vector<std::string> &args)
 {
+  // TODO implement this command
+  if (!args.empty())
+  {
+    logger(logging::ERROR) << "Usage: \"print_bci\"";
+    return true;
+  }
+
   m_core.print_blockchain_index();
+
   return true;
 }
 
@@ -376,13 +438,27 @@ bool DaemonCommandsHandler::print_tx(const std::vector<std::string> &args)
 //--------------------------------------------------------------------------------
 bool DaemonCommandsHandler::print_pool(const std::vector<std::string> &args)
 {
+  if (!args.empty())
+  {
+    logger(logging::ERROR) << "Usage: \"print_pool\"";
+    return true;
+  }
+
   logger(logging::INFO) << "Pool state: " << ENDL << m_core.print_pool(false);
+
   return true;
 }
 //--------------------------------------------------------------------------------
 bool DaemonCommandsHandler::print_pool_sh(const std::vector<std::string> &args)
 {
+  if (!args.empty())
+  {
+    logger(logging::ERROR) << "Usage: \"print_pool_sh\"";
+    return true;
+  }
+
   logger(logging::INFO) << "Pool state: " << ENDL << m_core.print_pool(true);
+
   return true;
 }
 //--------------------------------------------------------------------------------
@@ -415,7 +491,14 @@ bool DaemonCommandsHandler::start_mining(const std::vector<std::string> &args)
 //--------------------------------------------------------------------------------
 bool DaemonCommandsHandler::stop_mining(const std::vector<std::string> &args)
 {
+  if (!args.empty())
+  {
+    logger(logging::ERROR) << "Usage: \"stop_mining\"";
+    return true;
+  }
+
   m_core.get_miner().stop();
+
   return true;
 }
 

--- a/src/Daemon/DaemonCommandsHandler.h
+++ b/src/Daemon/DaemonCommandsHandler.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2011-2017 The Cryptonote developers
 // Copyright (c) 2017-2018 The Circle Foundation & Conceal Devs
-// Copyright (c) 2018-2021 Conceal Network & Conceal Devs
+// Copyright (c) 2018-2022 Conceal Network & Conceal Devs
 //
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -40,7 +40,7 @@ private:
   logging::LoggerRef logger;
   logging::LoggerManager& m_logManager;
 
-  std::string get_commands_str();
+  const std::string get_commands_str();
   bool print_block_by_height(uint32_t height);
   bool print_block_by_hash(const std::string& arg);
   uint64_t calculatePercent(const cn::Currency& currency, uint64_t value, uint64_t total);

--- a/src/HTTP/HttpParserErrorCodes.h
+++ b/src/HTTP/HttpParserErrorCodes.h
@@ -1,6 +1,6 @@
 // Copyright (c) 2011-2017 The Cryptonote developers
 // Copyright (c) 2017-2018 The Circle Foundation & Conceal Devs
-// Copyright (c) 2018-2021 Conceal Network & Conceal Devs
+// Copyright (c) 2018-2022 Conceal Network & Conceal Devs
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -12,11 +12,11 @@
 namespace cn {
 namespace error {
 
-enum HttpParserErrorCodes {
+enum class HttpParserErrorCodes : uint8_t {
   STREAM_NOT_GOOD = 1,
-  END_OF_STREAM,
-  UNEXPECTED_SYMBOL,
-  EMPTY_HEADER
+  END_OF_STREAM = 2,
+  UNEXPECTED_SYMBOL = 3,
+  EMPTY_HEADER = 4
 };
 
 // custom category:
@@ -24,21 +24,28 @@ class HttpParserErrorCategory : public std::error_category {
 public:
   static HttpParserErrorCategory INSTANCE;
 
-  virtual const char* name() const throw() override {
+  const char* name() const throw() override {
     return "HttpParserErrorCategory";
   }
 
-  virtual std::error_condition default_error_condition(int ev) const throw() override {
+  std::error_condition default_error_condition(int ev) const throw() override {
     return std::error_condition(ev, *this);
   }
 
-  virtual std::string message(int ev) const override {
-    switch (ev) {
-      case STREAM_NOT_GOOD: return "The stream is not good";
-      case END_OF_STREAM: return "The stream is ended";
-      case UNEXPECTED_SYMBOL: return "Unexpected symbol";
-      case EMPTY_HEADER: return "The header name is empty";
-      default: return "Unknown error";
+  std::string message(int ev) const override
+  {
+    switch (static_cast<HttpParserErrorCodes>(ev))
+    {
+      case HttpParserErrorCodes::STREAM_NOT_GOOD:
+        return "The stream is not good";
+      case HttpParserErrorCodes::END_OF_STREAM:
+        return "The stream is ended";
+      case HttpParserErrorCodes::UNEXPECTED_SYMBOL:
+        return "Unexpected symbol";
+      case HttpParserErrorCodes::EMPTY_HEADER:
+        return "The header name is empty";
+      default:
+        return "Unknown error";
     }
   }
 

--- a/src/PaymentGate/WalletService.cpp
+++ b/src/PaymentGate/WalletService.cpp
@@ -98,7 +98,8 @@ namespace payment_service
 
       crypto::Hash paymentId;
       bool r = common::podFromHex(paymentIdStr, paymentId);
-      assert(r);
+      if (!r)
+        assert(r);
 
       return paymentId;
     }
@@ -1138,7 +1139,6 @@ namespace payment_service
         spendingTransactionHash = common::podToHex(walletstx.hash);
       }
 
-      bool state = true;
       uint32_t knownBlockCount = node.getKnownBlockCount();
       if (knownBlockCount > unlockHeight)
       {
@@ -1445,8 +1445,8 @@ namespace payment_service
 
     /* Get the spend and view public keys from the address */
     const bool valid = cn::parseAccountAddressString(prefix,
-                                                             addr,
-                                                             address_str);
+                                                    addr,
+                                                    address_str);
 
     cn::BinaryArray ba;
     cn::toBinaryArray(addr, ba);
@@ -1458,6 +1458,11 @@ namespace payment_service
     integrated_address = tools::base_58::encode_addr(
         cn::parameters::CRYPTONOTE_PUBLIC_ADDRESS_BASE58_PREFIX,
         payment_id_str + keys);
+
+    if (!valid)
+    {
+      logger(logging::ERROR, logging::BRIGHT_RED) << "Could not parse address string!";
+    }
 
     return std::error_code();
   }

--- a/src/PaymentGateService/ConfigurationManager.cpp
+++ b/src/PaymentGateService/ConfigurationManager.cpp
@@ -44,7 +44,6 @@ bool ConfigurationManager::init(int argc, char** argv) {
 
   po::options_description netNodeOptions("Local Node Options");
   cn::NetNodeConfig::initOptions(netNodeOptions);
-  cn::CoreConfig::initOptions(netNodeOptions);
 
   po::options_description remoteNodeOptions("Daemon Options");
   RpcNodeConfiguration::initOptions(remoteNodeOptions);

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -498,9 +498,6 @@ bool RpcServer::k_on_check_tx_proof(const K_COMMAND_RPC_CHECK_TX_PROOF::request&
       throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Failed to generate key derivation" };
     }
 
-    // get tx pub key
-		crypto::PublicKey txPubKey = getTransactionPublicKeyFromExtra(transaction.extra);
-
 		// look for outputs
 		uint64_t received(0);
 		size_t keyIndex(0);
@@ -1408,7 +1405,7 @@ bool RpcServer::on_get_block_header_by_height(const COMMAND_RPC_GET_BLOCK_HEADER
 
   crypto::Hash tmp_hash = m_core.getBlockIdByHeight(req.height);
   bool is_orphaned = block_hash != tmp_hash;
-  fill_block_header_response(blk, false, req.height, block_hash, res.block_header);
+  fill_block_header_response(blk, is_orphaned, req.height, block_hash, res.block_header);
   res.status = CORE_RPC_STATUS_OK;
   return true;
 }

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -509,28 +509,6 @@ bool processServerAliasResponse(const std::string& s, std::string& address) {
 	return true;
 }
 
-
-
-bool splitUrlToHostAndUri(const std::string& aliasUrl, std::string& host, std::string& uri) {
-  size_t protoBegin = aliasUrl.find("http://");
-  if (protoBegin != 0 && protoBegin != std::string::npos) {
-    return false;
-  }
-
-  size_t hostBegin = protoBegin == std::string::npos ? 0 : 7; //strlen("http://")
-  size_t hostEnd = aliasUrl.find('/', hostBegin);
-
-  if (hostEnd == std::string::npos) {
-    uri = "/";
-    host = aliasUrl.substr(hostBegin);
-  } else {
-    uri = aliasUrl.substr(hostEnd);
-    host = aliasUrl.substr(hostBegin, hostEnd - hostBegin);
-  }
-
-  return true;
-}
-
 bool askAliasesTransfersConfirmation(const std::map<std::string, std::vector<WalletLegacyTransfer>>& aliases, const Currency& currency) {
   std::cout << "Would you like to send money to the following addresses?" << std::endl;
 

--- a/src/Wallet/PoolRpcServer.cpp
+++ b/src/Wallet/PoolRpcServer.cpp
@@ -342,8 +342,13 @@ bool pool_rpc_server::on_create_integrated(const wallet_rpc::COMMAND_RPC_CREATE_
 
     /* get the spend and view public keys from the address */
     const bool valid = cn::parseAccountAddressString(prefix, 
-                                                            addr,
-                                                            address_str);
+                                                    addr,
+                                                    address_str);
+    if (!valid)
+    {
+      logger(ERROR, BRIGHT_RED) << "Could not parse address string!";
+      return false;
+    }
 
     cn::BinaryArray ba;
     cn::toBinaryArray(addr, ba);

--- a/src/Wallet/WalletErrors.h
+++ b/src/Wallet/WalletErrors.h
@@ -54,7 +54,8 @@ enum WalletErrorCodes {
   DEPOSIT_WRONG_TERM,
   DESTINATION_ADDRESS_REQUIRED,
   DESTINATION_ADDRESS_NOT_FOUND,
-  DAEMON_NOT_SYNCED
+  DAEMON_NOT_SYNCED,
+  INVALID_TX_ID
 };
 
 // custom category:
@@ -112,6 +113,7 @@ public:
     case DEPOSIT_LOCKED:           return "Deposit is locked";
     case DEPOSIT_WRONG_TERM:       return "Incorrect term";
     case DAEMON_NOT_SYNCED:        return "Daemon is not synchronized";
+    case INVALID_TX_ID:            return "Invalid Transaction ID";
         default:
       return "Unknown error";
     }

--- a/src/Wallet/WalletGreen.cpp
+++ b/src/Wallet/WalletGreen.cpp
@@ -409,6 +409,8 @@ namespace cn
 
     transactionHash = common::podToHex(transaction->getTransactionHash());
     size_t id = validateSaveAndSendTransaction(*transaction, {}, false, true);
+    if (id == WALLET_INVALID_TRANSACTION_ID)
+      throw std::system_error(make_error_code(cn::error::INVALID_TX_ID));
   }
 
   crypto::SecretKey WalletGreen::getTransactionDeterministicSecretKey(crypto::Hash &transactionHash) const
@@ -619,6 +621,8 @@ namespace cn
     /* Return the transaction hash */
     transactionHash = common::podToHex(transaction->getTransactionHash());
     size_t id = validateSaveAndSendTransaction(*transaction, {}, false, true);
+    if (id == WALLET_INVALID_TRANSACTION_ID)
+      throw std::system_error(make_error_code(cn::error::INVALID_TX_ID));
   }
 
   void WalletGreen::validateOrders(const std::vector<WalletOrder> &orders) const
@@ -2256,6 +2260,8 @@ namespace cn
         updated = true;
       }
     });
+    if (!r)
+      return false;
 
     assert(r);
 
@@ -2320,6 +2326,9 @@ namespace cn
         updated = true;
       }
     });
+
+    if (!r)
+      return false;
 
     assert(r);
 
@@ -3785,7 +3794,8 @@ namespace cn
       crypto::Hash hash = transfer.transactionHash;
       TransactionInformation info;
       bool ok = container->getTransactionInformation(hash, info, NULL, NULL);
-      assert(ok);
+      if (!ok)
+        assert(ok);
       heights.push_back(info.blockHeight);
     }
     uint64_t unlocked = calculateDepositsAmount(transfers, m_currency, heights);

--- a/src/Wallet/WalletRpcServer.cpp
+++ b/src/Wallet/WalletRpcServer.cpp
@@ -479,8 +479,14 @@ bool wallet_rpc_server::on_create_integrated(const wallet_rpc::COMMAND_RPC_CREAT
 
     /* get the spend and view public keys from the address */
     const bool valid = cn::parseAccountAddressString(prefix, 
-                                                            addr,
-                                                            address_str);
+                                                    addr,
+                                                    address_str);
+
+    if (!valid)
+    {
+      logger(ERROR, BRIGHT_RED) << "Could not parse address string!";
+      return false;
+    }
 
     cn::BinaryArray ba;
     cn::toBinaryArray(addr, ba);

--- a/src/Wallet/WalletSerializationV1.cpp
+++ b/src/Wallet/WalletSerializationV1.cpp
@@ -720,7 +720,8 @@ void WalletSerializer::subscribeWallets() {
 
     auto& subscription = m_synchronizer.addSubscription(sub);
     bool r = index.modify(it, [&subscription] (WalletRecord& rec) { rec.container = &subscription.getContainer(); });
-    assert(r);
+    if (!r)
+      assert(r);
 
     subscription.addObserver(&m_transfersObserver);
   }

--- a/src/WalletLegacy/WalletLegacy.cpp
+++ b/src/WalletLegacy/WalletLegacy.cpp
@@ -1201,7 +1201,8 @@ std::vector<uint32_t> WalletLegacy::getTransactionHeights(const std::vector<Tran
 	  crypto::Hash hash = transfer.transactionHash;
 	  TransactionInformation info;
 	  bool ok = m_transferDetails->getTransactionInformation(hash, info, NULL, NULL);
-	  assert(ok);
+	  if (!ok)
+      assert(ok);
 	  heights.push_back(info.blockHeight);
   }
   return heights;

--- a/src/WalletLegacy/WalletTransactionSender.cpp
+++ b/src/WalletLegacy/WalletTransactionSender.cpp
@@ -134,22 +134,6 @@ namespace
     return result;
   }
 
-  uint64_t checkDepositsAndCalculateAmount(const std::vector<DepositId> &depositIds, const WalletUserTransactionsCache &transactionsCache)
-  {
-    uint64_t amount = 0;
-
-    for (const auto &id : depositIds)
-    {
-      Deposit deposit;
-      throwIf(!transactionsCache.getDeposit(id, deposit), error::DEPOSIT_DOESNOT_EXIST);
-      throwIf(deposit.locked, error::DEPOSIT_LOCKED);
-
-      amount += deposit.amount + deposit.interest;
-    }
-
-    return amount;
-  }
-
   void countDepositsTotalSumAndInterestSum(const std::vector<DepositId> &depositIds, WalletUserTransactionsCache &depositsCache,
                                            uint64_t &totalSum, uint64_t &interestsSum)
   {
@@ -921,6 +905,8 @@ namespace cn
 
       Deposit deposit;
       bool r = m_transactionsCache.getDeposit(id, deposit);
+      if (!r)
+        return false;
       assert(r);
 
       foundMoney += deposit.amount + deposit.interest;

--- a/tests/CoreTests/Chaingen.h
+++ b/tests/CoreTests/Chaingen.h
@@ -386,7 +386,6 @@ template<class t_test_class>
 inline bool do_replay_events(std::vector<test_event_entry>& events, t_test_class& validator)
 {
   boost::program_options::options_description desc("Allowed options");
-  cn::CoreConfig::initOptions(desc);
   command_line::add_arg(desc, command_line::arg_data_dir);
   boost::program_options::variables_map vm;
   bool r = command_line::handle_error_helper(desc, [&]()


### PR DESCRIPTION
This pull request focuses on the `conceal-core/src/CryptoNoteCore/` directory in regards to SonarCloud code smells (varies from minors to critical) from this link: https://sonarcloud.io/summary/overall?branch=branch-sonarcloud&id=bstera_conceal-core, this also includes some minor warnings the compiler will issue.

**Notes:**
- `CryptoNoteCore/CoreConfig.cpp` - The removal of `CoreConfig::initOptions`
  - <s>As this is an empty function, should we direct all previous calls of this to `CoreConfig::init`?</s>
  - `CoreConfig::initOptions` does nothing and `CoreConfig::init` is used by the daemon AFAIK so deleting `initOptions` is viable here without the need to replace it with another command, unless desired I.E making use of  `CoreConfig::initOptions`
- Update SonarCloud
  - <s>Can we get https://sonarcloud.io/summary/overall?branch=branch-sonarcloud&id=bstera_conceal-core updated for the latest warnings plus to check how we're doing.</s> I've just realised this updates with commits to the `master` branch
- Output Replacement
  - I've changed the output for `print_genesis_tx_hex()` simply to look *less* of a fork-friendly coin. Replaces the output so it only shows the tx hex with a note in the code's function. ( https://github.com/ConcealNetwork/conceal-core/commit/294c351f68ca7932a0574dc151ab14ce3fa18b60#diff-27ffaf977dfd8049469ad9e5ed661177aca0f0b98d08f2fcb387cebd98c3fb63R67)
- Code Comments
  - `json_log()` is called without `logging::INFO` or any alternative because it should produce `INFO` messages as standard, references: `conceal-core/src/Logging/LoggerRef.h#L17` & https://github.com/ConcealNetwork/conceal-core/pull/260/files#diff-b8cd663cf9074046bee8f3bb1c454ba97178173bcc5430c4c35712f1e837d3e9R26 

**Edit:**
- This pull request now covers `/Daemon/` + `HttpParserErrorCodes`
- Updated above notes for *"Requested to look at"*
- Updated *"Requested to look at"* to *"Notes"*