### PR TITLE
RPC: get raw txs and mempool methods

### DIFF
--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -1699,6 +1699,27 @@ namespace cn
     return true;
   }
 
+  bool Blockchain::getTransactionsWithOutputGlobalIndexes(const std::vector<crypto::Hash>& txs_ids, std::list<crypto::Hash>& missed_txs, std::vector<std::pair<Transaction, std::vector<uint32_t>>>& txs) {
+    std::lock_guard<decltype(m_blockchain_lock)> lk(m_blockchain_lock);
+
+    for (const auto& tx_id : txs_ids) {
+      auto it = m_transactionMap.find(tx_id);
+      if (it == m_transactionMap.end()) {
+        missed_txs.push_back(tx_id);
+      }
+      else {
+        const TransactionEntry& tx = transactionByIndex(it->second);
+        if (!(tx.m_global_output_indexes.size())) { 
+          logger(ERROR, BRIGHT_RED) << "Internal error: global indexes for transaction " << tx_id << " is empty"; 
+          return false;
+        }
+        txs.push_back(std::make_pair(tx.tx, tx.m_global_output_indexes));
+      }
+    }
+
+    return true;
+  }
+
   bool Blockchain::getAlternativeBlocks(std::list<Block> &blocks)
   {
     std::lock_guard<decltype(m_blockchain_lock)> lk(m_blockchain_lock);

--- a/src/CryptoNoteCore/Blockchain.h
+++ b/src/CryptoNoteCore/Blockchain.h
@@ -73,6 +73,7 @@ namespace cn
     bool getBlocks(uint32_t start_offset, uint32_t count, std::list<Block> &blocks, std::list<Transaction> &txs);
     bool getBlocks(uint32_t start_offset, uint32_t count, std::list<Block> &blocks);
     bool getAlternativeBlocks(std::list<Block> &blocks);
+    bool getTransactionsWithOutputGlobalIndexes(const std::vector<crypto::Hash>& txs_ids, std::list<crypto::Hash>& missed_txs, std::vector<std::pair<Transaction, std::vector<uint32_t>>>& txs);
     uint32_t getAlternativeBlocksCount();
     crypto::Hash getBlockIdByHeight(uint32_t height);
     bool getBlockByHash(const crypto::Hash &h, Block &blk);

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -122,6 +122,10 @@ void core::getTransactions(const std::vector<crypto::Hash>& txs_ids, std::list<T
   m_blockchain.getTransactions(txs_ids, txs, missed_txs, checkTxPool);
 }
 
+bool core::getTransactionsWithOutputGlobalIndexes(const std::vector<crypto::Hash>& txs_ids, std::list<crypto::Hash>& missed_txs, std::vector<std::pair<Transaction, std::vector<uint32_t>>>& txs) {
+  return m_blockchain.getTransactionsWithOutputGlobalIndexes(txs_ids, missed_txs, txs);
+}
+
 bool core::getTransaction(const crypto::Hash &id, Transaction &tx, bool checkTxPool)
 {
   std::vector<crypto::Hash> txs_ids;
@@ -646,6 +650,10 @@ std::vector<Transaction> core::getPoolTransactions() {
   }
 
   return result;
+}
+
+std::list<cn::tx_memory_pool::TransactionDetails> core::getMemoryPool() const {
+  return m_mempool.getMemoryPool();
 }
 
 std::vector<crypto::Hash> core::buildSparseChain() {

--- a/src/CryptoNoteCore/Core.h
+++ b/src/CryptoNoteCore/Core.h
@@ -106,6 +106,7 @@ namespace cn {
     virtual crypto::Hash getBlockIdByHeight(uint32_t height) override;
     virtual bool getTransaction(const crypto::Hash &id, Transaction &tx, bool checkTxPool = false) override;
     void getTransactions(const std::vector<crypto::Hash> &txs_ids, std::list<Transaction> &txs, std::list<crypto::Hash> &missed_txs, bool checkTxPool = false) override;
+    virtual bool getTransactionsWithOutputGlobalIndexes(const std::vector<crypto::Hash>& txs_ids, std::list<crypto::Hash>& missed_txs, std::vector<std::pair<Transaction, std::vector<uint32_t>>>& txs) override;
     virtual bool getBlockByHash(const crypto::Hash &h, Block &blk) override;
     virtual bool getBlockHeight(const crypto::Hash &blockId, uint32_t &blockHeight) override;
     //void get_all_known_block_ids(std::list<crypto::Hash> &main, std::list<crypto::Hash> &alt, std::list<crypto::Hash> &invalid);
@@ -137,6 +138,7 @@ namespace cn {
     void print_blockchain(uint32_t start_index, uint32_t end_index);
     void print_blockchain_index();
     std::string print_pool(bool short_format);
+    std::list<cn::tx_memory_pool::TransactionDetails> getMemoryPool() const;
     void print_blockchain_outs(const std::string &file);
     virtual bool getPoolChanges(const crypto::Hash &tailBlockId, const std::vector<crypto::Hash> &knownTxsIds,
                                 std::vector<Transaction> &addedTxs, std::vector<crypto::Hash> &deletedTxsIds) override;

--- a/src/CryptoNoteCore/ICore.h
+++ b/src/CryptoNoteCore/ICore.h
@@ -90,6 +90,7 @@ public:
   virtual bool getBlockByHash(const crypto::Hash &h, Block &blk) = 0;
   virtual bool getBlockHeight(const crypto::Hash& blockId, uint32_t& blockHeight) = 0;
   virtual void getTransactions(const std::vector<crypto::Hash>& txs_ids, std::list<Transaction>& txs, std::list<crypto::Hash>& missed_txs, bool checkTxPool = false) = 0;
+  virtual bool getTransactionsWithOutputGlobalIndexes(const std::vector<crypto::Hash>& txs_ids, std::list<crypto::Hash>& missed_txs, std::vector<std::pair<Transaction, std::vector<uint32_t>>>& txs) = 0;
   virtual bool getBackwardBlocksSizes(uint32_t fromHeight, std::vector<size_t>& sizes, size_t count) = 0;
   virtual bool getBlockSize(const crypto::Hash& hash, size_t& size) = 0;
   virtual bool getAlreadyGeneratedCoins(const crypto::Hash& hash, uint64_t& generatedCoins) = 0;

--- a/src/CryptoNoteCore/TransactionPool.cpp
+++ b/src/CryptoNoteCore/TransactionPool.cpp
@@ -888,4 +888,14 @@ namespace cn
     std::lock_guard<std::recursive_mutex> lock(m_transactions_lock);
     return m_timestampIndex.find(timestampBegin, timestampEnd, transactionsNumberLimit, hashes, transactionsNumberWithinTimestamps);
   }
+  
+  std::list<cn::tx_memory_pool::TransactionDetails> tx_memory_pool::getMemoryPool() const {
+    std::lock_guard<std::recursive_mutex> lock(m_transactions_lock);
+    std::list<tx_memory_pool::TransactionDetails> txs;
+    for (const auto& txd : m_fee_index) {
+      txs.push_back(txd);
+    }
+    return txs;
+  }
+
 } // namespace cn

--- a/src/CryptoNoteCore/TransactionPool.h
+++ b/src/CryptoNoteCore/TransactionPool.h
@@ -141,6 +141,8 @@ namespace cn {
       time_t receiveTime;
     };
 
+    std::list<cn::tx_memory_pool::TransactionDetails> getMemoryPool() const;
+
   private:
 
     struct TransactionPriorityComparator {

--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -919,6 +919,68 @@ struct COMMAND_RPC_GET_BLOCK_DETAILS_BY_HEIGHT
   };
 };
 
+struct tx_with_output_global_indexes {
+  TransactionPrefix transaction;
+  crypto::Hash hash;
+  crypto::Hash block_hash;
+  uint32_t height;
+  uint64_t fee;
+  uint64_t timestamp;
+  std::vector<uint32_t> output_indexes;
+
+  void serialize(ISerializer &s)
+  {
+    KV_MEMBER(transaction)
+    KV_MEMBER(hash)
+    KV_MEMBER(block_hash)
+    KV_MEMBER(height)
+    KV_MEMBER(fee)
+    KV_MEMBER(timestamp)
+    KV_MEMBER(output_indexes)
+  }
+};
+
+struct COMMAND_RPC_GET_TRANSACTIONS_WITH_OUTPUT_GLOBAL_INDEXES {
+  struct request {
+    std::vector<uint32_t> heights;
+    bool include_miner_txs = true;
+    bool range = false;
+
+    void serialize(ISerializer &s) {
+      KV_MEMBER(heights)
+      KV_MEMBER(include_miner_txs)
+      KV_MEMBER(range)
+    };
+  };
+
+  struct response {
+    std::vector<tx_with_output_global_indexes> transactions;
+    std::list<std::string> missed_txs;
+    std::string status;
+
+    void serialize(ISerializer &s)
+    {
+      KV_MEMBER(transactions)
+      KV_MEMBER(missed_txs)
+      KV_MEMBER(status)
+    }
+  };
+};
+
+struct COMMAND_RPC_GET_RAW_TRANSACTIONS_POOL {
+  typedef EMPTY_STRUCT request;
+
+  struct response {
+    std::vector<tx_with_output_global_indexes> transactions;
+    std::string status;
+
+    void serialize(ISerializer &s) {
+      KV_MEMBER(transactions)
+      KV_MEMBER(status)
+    }
+  };
+};
+
 struct K_COMMAND_RPC_CHECK_TX_PROOF {
     struct request {
         std::string tx_id;

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -70,6 +70,12 @@ RpcServer::HandlerFunction jsonMethod(bool (RpcServer::*handler)(typename Comman
     }
 
     bool result = (obj->*handler)(req, res);
+
+    response.addHeader("Access-Control-Allow-Origin", "*");
+    response.addHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+    response.addHeader("Access-Control-Allow-Methods", "POST, GET");
+    response.addHeader("Content-Type", "application/json");
+
     response.setBody(storeToJson(res.data()));
     return result;
   };
@@ -130,6 +136,9 @@ bool RpcServer::processJsonRpcRequest(const HttpRequest& request, HttpResponse& 
   using namespace JsonRpc;
 
   response.addHeader("Content-Type", "application/json");
+  response.addHeader("Access-Control-Allow-Origin", "*");
+  response.addHeader("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+  response.addHeader("Access-Control-Allow-Methods", "POST, GET");
 
   JsonRpcRequest jsonRequest;
   JsonRpcResponse jsonResponse;

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -35,7 +35,7 @@ using namespace logging;
 using namespace crypto;
 using namespace common;
 
-
+const uint64_t BLOCK_LIST_MAX_COUNT = 1000;
 
 namespace cn {
 
@@ -96,6 +96,8 @@ std::unordered_map<std::string, RpcServer::RpcHandler<RpcServer::HandlerFunction
   { "/feeaddress", { jsonMethod<COMMAND_RPC_GET_FEE_ADDRESS>(&RpcServer::on_get_fee_address), true } },
   { "/peers", { jsonMethod<COMMAND_RPC_GET_PEER_LIST>(&RpcServer::on_get_peer_list), true } },
   { "/getpeers", { jsonMethod<COMMAND_RPC_GET_PEER_LIST>(&RpcServer::on_get_peer_list), true } },
+  { "/get_raw_transactions_by_heights", { jsonMethod<COMMAND_RPC_GET_TRANSACTIONS_WITH_OUTPUT_GLOBAL_INDEXES>(&RpcServer::on_get_txs_with_output_global_indexes), true } },
+  { "/getrawtransactionspool", { jsonMethod<COMMAND_RPC_GET_RAW_TRANSACTIONS_POOL>(&RpcServer::on_get_transactions_pool_raw), true } },
 
   // json rpc
   { "/json_rpc", { std::bind(&RpcServer::processJsonRpcRequest, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3), true } }
@@ -155,7 +157,10 @@ bool RpcServer::processJsonRpcRequest(const HttpRequest& request, HttpResponse& 
         {"getlastblockheader", {makeMemberMethod(&RpcServer::on_get_last_block_header), false}},
         {"getblockheaderbyhash", {makeMemberMethod(&RpcServer::on_get_block_header_by_hash), false}},
         {"getblocktimestamp", {makeMemberMethod(&RpcServer::on_get_block_timestamp_by_height), true}},
-        {"getblockheaderbyheight", {makeMemberMethod(&RpcServer::on_get_block_header_by_height), false}}};
+        {"getblockheaderbyheight", {makeMemberMethod(&RpcServer::on_get_block_header_by_height), false}},
+        {"getrawtransactionspool", {makeMemberMethod(&RpcServer::on_get_transactions_pool_raw), true}},
+        {"getrawtransactionsbyheights", {makeMemberMethod(&RpcServer::on_get_txs_with_output_global_indexes), true}}
+    };
 
     auto it = jsonRpcHandlers.find(jsonRequest.getMethod());
     if (it == jsonRpcHandlers.end()) {
@@ -422,6 +427,121 @@ bool RpcServer::on_get_block_details_by_height(const COMMAND_RPC_GET_BLOCK_DETAI
   }
 
   res.block = blockDetails;
+  res.status = CORE_RPC_STATUS_OK;
+  return true;
+}
+
+bool RpcServer::on_get_txs_with_output_global_indexes(const COMMAND_RPC_GET_TRANSACTIONS_WITH_OUTPUT_GLOBAL_INDEXES::request& req, COMMAND_RPC_GET_TRANSACTIONS_WITH_OUTPUT_GLOBAL_INDEXES::response& rsp) {
+  try {
+    std::vector<uint32_t> heights;
+    
+    if (req.range) {
+      if (req.heights.size() != 2) {
+        throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM,
+          std::string("The range is set to true but heights size is not equal to 2") };
+      }
+      std::vector<uint32_t> range = req.heights;
+
+      if (range.back() - range.front() > BLOCK_LIST_MAX_COUNT) {
+        throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM,
+          std::string("Requested blocks count: ") + std::to_string(range.back() - range.front()) + " exceeded max limit of " + std::to_string(BLOCK_LIST_MAX_COUNT) };
+      }
+
+      std::sort(range.begin(), range.end());
+      uint32_t upperBound = std::min(range[1], m_core.get_current_blockchain_height());
+      for (size_t i = 0; i < (upperBound - range[0]); i++) {
+        heights.push_back(range[0] + i);
+      }
+    }
+    else {
+      if (req.heights.size() > BLOCK_LIST_MAX_COUNT) {
+        throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_WRONG_PARAM,
+          std::string("Requested blocks count: ") + std::to_string(req.heights.size()) + " exceeded max limit of " + std::to_string(BLOCK_LIST_MAX_COUNT) };
+      }
+
+      heights = req.heights;
+    }
+
+    for (const uint32_t& height : heights) {
+      if (m_core.get_current_blockchain_height() <= height) {
+        throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_TOO_BIG_HEIGHT,
+          std::string("To big height: ") + std::to_string(height) + ", current blockchain height = " + std::to_string(m_core.get_current_blockchain_height() - 1) };
+      }
+
+      crypto::Hash block_hash = m_core.getBlockIdByHeight(height);
+      Block blk;
+      if (!m_core.getBlockByHash(block_hash, blk)) {
+        throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Internal error: can't get block by height " + std::to_string(height) + '.' };
+      }
+
+      std::vector<crypto::Hash> txs_ids;
+
+      if (req.include_miner_txs) {
+        txs_ids.reserve(blk.transactionHashes.size() + 1);
+        txs_ids.push_back(getObjectHash(blk.baseTransaction));
+      }
+      else {
+        txs_ids.reserve(blk.transactionHashes.size());
+      }
+      if (!blk.transactionHashes.empty()) {
+        txs_ids.insert(txs_ids.end(), blk.transactionHashes.begin(), blk.transactionHashes.end());
+      }
+
+      std::vector<crypto::Hash>::const_iterator ti = txs_ids.begin();
+
+      std::vector<std::pair<Transaction, std::vector<uint32_t>>> txs;
+      std::list<crypto::Hash> missed;
+
+      if (!txs_ids.empty()) {
+        if (!m_core.getTransactionsWithOutputGlobalIndexes(txs_ids, missed, txs)) {
+          throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Error getting transactions with output global indexes" };
+        }
+
+        for (const auto &txi : txs) {
+          rsp.transactions.push_back(tx_with_output_global_indexes());
+          tx_with_output_global_indexes &e = rsp.transactions.back();
+
+          e.hash = *ti++;
+          e.block_hash = block_hash;
+          e.height = height;
+          e.timestamp = blk.timestamp;
+          e.transaction = *static_cast<const TransactionPrefix*>(&txi.first);
+          e.output_indexes = txi.second;
+          e.fee = is_coinbase(txi.first) ? 0 : getInputAmount(txi.first) - getOutputAmount(txi.first);
+        }
+      }
+
+      for (const auto& miss_tx : missed) {
+        rsp.missed_txs.push_back(common::podToHex(miss_tx));
+      }
+    }
+  }
+  catch (std::system_error& e) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, e.what() };
+    return false;
+  }
+  catch (std::exception& e) {
+    throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Error: " + std::string(e.what()) };
+    return false;
+  }
+  rsp.status = CORE_RPC_STATUS_OK;
+  return true;
+}
+
+bool RpcServer::on_get_transactions_pool_raw(const COMMAND_RPC_GET_RAW_TRANSACTIONS_POOL::request& req, COMMAND_RPC_GET_RAW_TRANSACTIONS_POOL::response& res) {
+  auto pool = m_core.getMemoryPool();
+
+  for (const auto& txd : pool) {
+    res.transactions.push_back(tx_with_output_global_indexes());
+    tx_with_output_global_indexes &e = res.transactions.back();
+
+    e.hash = txd.id;
+    e.height = boost::value_initialized<uint32_t>();
+    e.block_hash = boost::value_initialized<crypto::Hash>();
+    e.timestamp = txd.receiveTime;
+    e.transaction = *static_cast<const TransactionPrefix*>(&txd.tx);
+    e.fee = txd.fee;
+  }
   res.status = CORE_RPC_STATUS_OK;
   return true;
 }

--- a/src/Rpc/RpcServer.h
+++ b/src/Rpc/RpcServer.h
@@ -67,6 +67,7 @@ private:
   bool on_stop_daemon(const COMMAND_RPC_STOP_DAEMON::request& req, COMMAND_RPC_STOP_DAEMON::response& res);
   bool on_get_fee_address(const COMMAND_RPC_GET_FEE_ADDRESS::request& req, COMMAND_RPC_GET_FEE_ADDRESS::response& res);
   bool on_alt_blocks_list_json(const COMMAND_RPC_GET_ALT_BLOCKS_LIST::request &req, COMMAND_RPC_GET_ALT_BLOCKS_LIST::response &res);
+  bool on_get_txs_with_output_global_indexes(const COMMAND_RPC_GET_TRANSACTIONS_WITH_OUTPUT_GLOBAL_INDEXES::request& req, COMMAND_RPC_GET_TRANSACTIONS_WITH_OUTPUT_GLOBAL_INDEXES::response& rsp);
 
   // json rpc
   bool on_getblockcount(const COMMAND_RPC_GETBLOCKCOUNT::request& req, COMMAND_RPC_GETBLOCKCOUNT::response& res);
@@ -79,6 +80,7 @@ private:
   bool on_get_block_header_by_height(const COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT::request& req, COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT::response& res);
   bool on_get_block_timestamp_by_height(const COMMAND_RPC_GET_BLOCK_TIMESTAMP_BY_HEIGHT::request& req, COMMAND_RPC_GET_BLOCK_TIMESTAMP_BY_HEIGHT::response& res);
   bool on_get_block_details_by_height(const COMMAND_RPC_GET_BLOCK_DETAILS_BY_HEIGHT::request& req, COMMAND_RPC_GET_BLOCK_DETAILS_BY_HEIGHT::response& res);
+  bool on_get_transactions_pool_raw(const COMMAND_RPC_GET_RAW_TRANSACTIONS_POOL::request& req, COMMAND_RPC_GET_RAW_TRANSACTIONS_POOL::response& res);
 
   void fill_block_header_response(const Block& blk, bool orphan_status, uint64_t height, const crypto::Hash& hash, block_header_response& responce);
 


### PR DESCRIPTION
This adds required CORS headers as well as two methods that allow browser wallet to work with node directly: POST `getrawtransactionsbyheights` and `getrawtransactionspool` and corresponding GET handlers `/get_raw_transactions_by_heights`, `/getrawtransactionspool` 

