### PR TITLE
Banking features to `concealwallet`

### DIFF
--- a/include/IWalletLegacy.h
+++ b/include/IWalletLegacy.h
@@ -98,6 +98,7 @@ public:
   virtual void externalTransactionCreated(TransactionId transactionId) {}
   virtual void sendTransactionCompleted(TransactionId transactionId, std::error_code result) {}
   virtual void transactionUpdated(TransactionId transactionId) {}
+  virtual void depositUpdated(const DepositId& depositId) {}
   virtual void depositsUpdated(const std::vector<DepositId>& depositIds) {}
 };
 
@@ -152,6 +153,7 @@ public:
   virtual std::list<TransactionOutputInformation> selectFusionTransfersToSend(uint64_t threshold, size_t minInputCount, size_t maxInputCount) = 0;
   virtual TransactionId sendFusionTransaction(const std::list<TransactionOutputInformation>& fusionInputs, uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0) = 0;
   virtual TransactionId deposit(uint32_t term, uint64_t amount, uint64_t fee, uint64_t mixIn = 0) = 0;
+  virtual TransactionId withdrawDeposit(const DepositId& depositId, uint64_t fee) = 0;
   virtual TransactionId withdrawDeposits(const std::vector<DepositId>& depositIds, uint64_t fee) = 0;
   virtual std::error_code cancelTransaction(size_t transferId) = 0;
 

--- a/src/P2p/NetNode.cpp
+++ b/src/P2p/NetNode.cpp
@@ -77,7 +77,7 @@ void addPortMapping(logging::LoggerRef& logger, uint32_t port) {
       std::ostringstream portString;
       portString << port;
       if (UPNP_AddPortMapping(urls.controlURL, igdData.first.servicetype, portString.str().c_str(),
-        portString.str().c_str(), lanAddress, "Conceal", "TCP", 0, "0") != 0) {
+        portString.str().c_str(), lanAddress, "conceal", "TCP", 0, "0") != 0) {
         logger(ERROR) << "UPNP_AddPortMapping failed.";
       } else {
         logger(INFO, BRIGHT_GREEN) << "Added IGD port mapping.";

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -672,6 +672,7 @@ simple_wallet::simple_wallet(platform_system::Dispatcher& dispatcher, const cn::
   m_consoleHandler.setHandler("save_keys", boost::bind(&simple_wallet::save_keys_to_file, this, boost::arg<1>()), "Saves wallet private keys to \"<wallet_name>_conceal_backup.txt\"");
   m_consoleHandler.setHandler("list_deposits", boost::bind(&simple_wallet::list_deposits, this, boost::arg<1>()), "Show all known deposits from this wallet");
   m_consoleHandler.setHandler("deposit", boost::bind(&simple_wallet::deposit, this, boost::arg<1>()), "deposit <months> <amount> - Create a deposit");
+  m_consoleHandler.setHandler("withdraw", boost::bind(&simple_wallet::withdraw, this, boost::arg<1>()), "withdraw <id> - Withdraw a deposit");
 }
 
 std::string simple_wallet::simple_menu()
@@ -691,6 +692,7 @@ std::string simple_wallet::simple_menu()
   menu_item += "\"transfer <address> <amount>\" - Transfers <amount> to <address>. | [-p<payment_id>] [<amount_2>]...[<amount_N>] [<address_2>]...[<address_n>]\n";
   menu_item += "\"save\"                        - Save wallet synchronized blockchain data.\n";
   menu_item += "\"save_keys\"                   - Saves wallet private keys to \"<wallet_name>_conceal_backup.txt\".\n";
+  menu_item += "\"withdraw <id>\"               - Withdraw a deposit from the blockchain.\n";
   return menu_item;
 }
 
@@ -2150,6 +2152,65 @@ bool simple_wallet::deposit(const std::vector<std::string> &args)
   }
 
   return true;
+}
+
+bool simple_wallet::withdraw(const std::vector<std::string> &args)
+{
+  if (args.size() != 1)
+  {
+    logger(ERROR) << "Usage: withdraw <id>";
+    return true;
+  }
+
+  try
+  {
+    if (m_wallet->getDepositCount() == 0)
+    {
+      logger(ERROR) << "No deposits have been made in this wallet.";
+      return true;
+    }
+
+    uint64_t deposit_id = boost::lexical_cast<uint64_t>(args[0]);
+    uint64_t deposit_fee = cn::parameters::MINIMUM_FEE_V2;
+    
+    cn::WalletHelper::SendCompleteResultObserver sent;
+    WalletHelper::IWalletRemoveObserverGuard removeGuard(*m_wallet, sent);
+
+    cn::TransactionId tx = m_wallet->withdrawDeposit(deposit_id, deposit_fee);
+  
+    if (tx == WALLET_LEGACY_INVALID_DEPOSIT_ID)
+    {
+      fail_msg_writer() << "Can't withdraw money";
+      return true;
+    }
+
+    std::error_code sendError = sent.wait(tx);
+    removeGuard.removeObserver();
+
+    if (sendError)
+    {
+      fail_msg_writer() << sendError.message();
+      return true;
+    }
+
+    cn::Deposit d_info;
+    m_wallet->getDeposit(tx, d_info);
+    success_msg_writer(true) << "Money has successfully been withdrawn\n\ttransaction hash: " << common::podToHex(d_info.transactionHash);
+
+    try
+    {
+      cn::WalletHelper::storeWallet(*m_wallet, m_wallet_file);
+    }
+    catch (const std::exception& e)
+    {
+      fail_msg_writer() << e.what();
+      return true;
+    }
+  }
+  catch (std::exception &e)
+  {
+    fail_msg_writer() << "failed to withdraw deposit: " << e.what();
+  }
 }
 
 int main(int argc, char* argv[]) {

--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -671,6 +671,7 @@ simple_wallet::simple_wallet(platform_system::Dispatcher& dispatcher, const cn::
   m_consoleHandler.setHandler("get_reserve_proof", boost::bind(&simple_wallet::get_reserve_proof, this, boost::arg<1>()), "all|<amount> [<message>] - Generate a signature proving that you own at least <amount>, optionally with a challenge string <message>. ");
   m_consoleHandler.setHandler("save_keys", boost::bind(&simple_wallet::save_keys_to_file, this, boost::arg<1>()), "Saves wallet private keys to \"<wallet_name>_conceal_backup.txt\"");
   m_consoleHandler.setHandler("list_deposits", boost::bind(&simple_wallet::list_deposits, this, boost::arg<1>()), "Show all known deposits from this wallet");
+  m_consoleHandler.setHandler("deposit", boost::bind(&simple_wallet::deposit, this, boost::arg<1>()), "deposit <months> <amount> - Create a deposit");
 }
 
 std::string simple_wallet::simple_menu()
@@ -680,6 +681,7 @@ std::string simple_wallet::simple_menu()
   menu_item += "\"address\"                     - Shows wallet address.\n";
   menu_item += "\"balance\"                     - Shows wallet balance.\n";
   menu_item += "\"bc_height\"                   - Shows current blockchain height.\n";
+  menu_item += "\"deposit <months> <amount>\"   - Create a deposit to the blockchain.\n";
   menu_item += "\"exit\"                        - Safely exits the wallet application.\n";
   menu_item += "\"export_keys\"                 - Displays backup keys.\n";
   menu_item += "\"help\" | \"ext_help\"           - Shows this help dialog or extended help dialog.\n";
@@ -2038,6 +2040,113 @@ bool simple_wallet::list_deposits(const std::vector<std::string> &args)
 
   if (!haveDeposits) {
     success_msg_writer() << "No deposits";
+  }
+
+  return true;
+}
+
+bool simple_wallet::deposit(const std::vector<std::string> &args)
+{
+  if (args.size() != 2)
+  {
+    logger(ERROR) << "Usage: deposit <months> <amount>";
+    return true;
+  }
+
+  try
+  {
+    /**
+     * Change arg to uint64_t using boost then
+     * multiply by min_term so user can type in months
+    **/
+    uint64_t deposit_term = boost::lexical_cast<uint64_t>(args[0]) * 21900;
+
+    /* Now validate the deposit term and the amount */
+    if (deposit_term < cn::parameters::DEPOSIT_MIN_TERM_V3)
+    {
+      logger(ERROR, BRIGHT_RED) << "Deposit term is too small, min=21900, given=" << deposit_term;
+      return true;
+    }
+
+    if (deposit_term > cn::parameters::DEPOSIT_MAX_TERM_V3)
+    {
+      logger(ERROR, BRIGHT_RED) << "Deposit term is too big, min=" << cn::parameters::DEPOSIT_MAX_TERM_V3
+        << ", given=" << deposit_term;
+      return true;
+    }
+
+    uint64_t deposit_amount = boost::lexical_cast<uint64_t>(args[1]);
+    bool ok = m_currency.parseAmount(args[1], deposit_amount);
+
+    if (!ok || 0 == deposit_amount)
+    {
+      logger(ERROR, BRIGHT_RED) << "amount is wrong: " << deposit_amount <<
+        ", expected number from 1 to " << m_currency.formatAmount(cn::parameters::MONEY_SUPPLY);
+      return true;
+    }
+
+    if (deposit_amount < cn::parameters::DEPOSIT_MIN_AMOUNT)
+    {
+      logger(ERROR, BRIGHT_RED) << "Deposit amount is too small, min=" << cn::parameters::DEPOSIT_MIN_AMOUNT
+        << ", given=" << m_currency.formatAmount(deposit_amount);
+      return true;
+    }
+
+    if (!confirm_deposit(deposit_term, deposit_amount))
+    {
+      logger(ERROR) << "Deposit is not being created."
+      return true;
+    }
+
+    /* Use defaults for fee + mix in */
+    uint64_t deposit_fee = cn::parameters::MINIMUM_FEE_V2;
+    uint64_t deposit_mix_in = cn::parameters::MINIMUM_MIXIN;
+
+    cn::WalletHelper::SendCompleteResultObserver sent;
+    WalletHelper::IWalletRemoveObserverGuard removeGuard(*m_wallet, sent);
+
+    cn::TransactionId tx = m_wallet->deposit(deposit_term, deposit_amount, deposit_fee, deposit_mix_in);
+
+    if (tx == WALLET_LEGACY_INVALID_DEPOSIT_ID)
+    {
+      fail_msg_writer() << "Can't deposit money";
+      return true;
+    }
+
+    std::error_code sendError = sent.wait(tx);
+    removeGuard.removeObserver();
+
+    if (sendError)
+    {
+      fail_msg_writer() << sendError.message();
+      return true;
+    }
+
+    cn::Deposit d_info;
+    m_wallet->getDeposit(tx, d_info);
+    success_msg_writer(true) << "Money successfully sent, transaction hash: " << common::podToHex(d_info.transactionHash);
+
+    try
+    {
+      cn::WalletHelper::storeWallet(*m_wallet, m_wallet_file);
+    }
+    catch (const std::exception& e)
+    {
+      fail_msg_writer() << e.what();
+      return true;
+    }
+  }
+  catch (const std::system_error& e)
+  {
+    fail_msg_writer() << e.what();
+  }
+  catch (const std::exception& e)
+  {
+    fail_msg_writer() << e.what();
+  }
+  catch (...)
+  {
+    fail_msg_writer() << "unknown error";
   }
 
   return true;

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -97,6 +97,7 @@ namespace cn
     bool save_keys_to_file(const std::vector<std::string> &args);
 
     bool deposit(const std::vector<std::string> &args);
+    bool withdraw(const std::vector<std::string> &args);
     bool list_deposits(const std::vector<std::string> &args);
 
     std::string simple_menu();

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -96,6 +96,8 @@ namespace cn
     bool set_log(const std::vector<std::string> &args);
     bool save_keys_to_file(const std::vector<std::string> &args);
 
+    bool list_deposits(const std::vector<std::string> &args);
+
     std::string simple_menu();
     std::string extended_menu();
 

--- a/src/SimpleWallet/SimpleWallet.h
+++ b/src/SimpleWallet/SimpleWallet.h
@@ -96,6 +96,7 @@ namespace cn
     bool set_log(const std::vector<std::string> &args);
     bool save_keys_to_file(const std::vector<std::string> &args);
 
+    bool deposit(const std::vector<std::string> &args);
     bool list_deposits(const std::vector<std::string> &args);
 
     std::string simple_menu();

--- a/src/WalletLegacy/WalletLegacy.cpp
+++ b/src/WalletLegacy/WalletLegacy.cpp
@@ -804,6 +804,34 @@ TransactionId WalletLegacy::deposit(uint32_t term, uint64_t amount, uint64_t fee
   return txId;
 }
 
+TransactionId WalletLegacy::withdrawDeposit(const DepositId& depositId, uint64_t fee) {
+  throwIfNotInitialised();
+
+  TransactionId txId = 0;
+  std::unique_ptr<WalletRequest> request;
+  std::deque<std::unique_ptr<WalletLegacyEvent>> events;
+
+  fee = cn::parameters::MINIMUM_FEE;
+
+  {
+    std::unique_lock<std::mutex> lock(m_cacheMutex);
+    request = m_sender->makeWithdrawDepositRequest(txId, events, depositId, fee);
+
+    if (request != nullptr) {
+      pushBalanceUpdatedEvents(events);
+    }
+  }
+
+  notifyClients(events);
+
+  if (request != nullptr) {
+    m_asyncContextCounter.addAsyncContext();
+    request->perform(m_node, std::bind(&WalletLegacy::sendTransactionCallback, this, std::placeholders::_1, std::placeholders::_2));
+  }
+
+  return txId;
+}
+
 TransactionId WalletLegacy::withdrawDeposits(const std::vector<DepositId>& depositIds, uint64_t fee) {
   throwIfNotInitialised();
 
@@ -815,7 +843,7 @@ TransactionId WalletLegacy::withdrawDeposits(const std::vector<DepositId>& depos
 
   {
     std::unique_lock<std::mutex> lock(m_cacheMutex);
-    request = m_sender->makeWithdrawDepositRequest(txId, events, depositIds, fee);
+    request = m_sender->makeWithdrawDepositsRequest(txId, events, depositIds, fee);
 
     if (request != nullptr) {
       pushBalanceUpdatedEvents(events);

--- a/src/WalletLegacy/WalletLegacy.h
+++ b/src/WalletLegacy/WalletLegacy.h
@@ -102,6 +102,7 @@ public:
   virtual std::list<TransactionOutputInformation> selectFusionTransfersToSend(uint64_t threshold, size_t minInputCount, size_t maxInputCount);
   virtual TransactionId sendFusionTransaction(const std::list<TransactionOutputInformation>& fusionInputs, uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0);
   virtual TransactionId deposit(uint32_t term, uint64_t amount, uint64_t fee, uint64_t mixIn = parameters::MINIMUM_MIXIN) override;
+  virtual TransactionId withdrawDeposit(const DepositId& depositId, uint64_t fee) override;
   virtual TransactionId withdrawDeposits(const std::vector<DepositId>& depositIds, uint64_t fee) override;
   virtual std::error_code cancelTransaction(size_t transactionId) override;
 

--- a/src/WalletLegacy/WalletLegacyEvent.h
+++ b/src/WalletLegacy/WalletLegacyEvent.h
@@ -67,6 +67,19 @@ private:
   TransactionId m_id;
 };
 
+class WalletDepositUpdatedEvent : public WalletLegacyEvent {
+public:
+  WalletDepositUpdatedEvent(DepositId& depositId) : updatedDeposit(depositId) {}
+
+  virtual ~WalletDepositUpdatedEvent() {}
+
+  virtual void notify(tools::ObserverManager<cn::IWalletLegacyObserver>& observer) override {
+    observer.notify(&IWalletLegacyObserver::depositUpdated, updatedDeposit);
+  }
+private:
+  DepositId updatedDeposit;
+};
+
 class WalletDepositsUpdatedEvent : public WalletLegacyEvent {
 public:
   WalletDepositsUpdatedEvent(std::vector<DepositId>&& depositIds) : updatedDeposits(depositIds) {}

--- a/src/WalletLegacy/WalletTransactionSender.cpp
+++ b/src/WalletLegacy/WalletTransactionSender.cpp
@@ -151,6 +151,16 @@ namespace
     return amount;
   }
 
+  void countDepositTotalSumAndInterestSum(const DepositId &depositId, WalletUserTransactionsCache &depositsCache,
+                                           uint64_t &totalSum, uint64_t &interestsSum)
+  {
+    totalSum = 0;
+    interestsSum = 0;
+    Deposit &deposit = depositsCache.getDeposit(depositId);
+    totalSum += deposit.amount + deposit.interest;
+    interestsSum += deposit.interest;
+  }
+
   void countDepositsTotalSumAndInterestSum(const std::vector<DepositId> &depositIds, WalletUserTransactionsCache &depositsCache,
                                            uint64_t &totalSum, uint64_t &interestsSum)
   {
@@ -298,6 +308,27 @@ namespace cn
 
   std::unique_ptr<WalletRequest> WalletTransactionSender::makeWithdrawDepositRequest(TransactionId &transactionId,
                                                                                      std::deque<std::unique_ptr<WalletLegacyEvent>> &events,
+                                                                                     const DepositId &depositId,
+                                                                                     uint64_t fee)
+  {
+
+    std::shared_ptr<SendTransactionContext> context = std::make_shared<SendTransactionContext>();
+    context->dustPolicy.dustThreshold = m_currency.defaultDustThreshold();
+
+    context->foundMoney = selectDepositTransfers(depositId, context->selectedTransfers);
+    throwIf(context->foundMoney < fee, error::WRONG_AMOUNT);
+
+    transactionId = m_transactionsCache.addNewTransaction(context->foundMoney, fee, std::string(), {}, 0, {});
+    context->transactionId = transactionId;
+    context->mixIn = 0;
+
+    setSpendingTransactionToDeposit(transactionId, depositId);
+
+    return doSendDepositWithdrawTransaction(std::move(context), events, depositId);
+  }
+
+  std::unique_ptr<WalletRequest> WalletTransactionSender::makeWithdrawDepositsRequest(TransactionId &transactionId,
+                                                                                     std::deque<std::unique_ptr<WalletLegacyEvent>> &events,
                                                                                      const std::vector<DepositId> &depositIds,
                                                                                      uint64_t fee)
   {
@@ -305,7 +336,7 @@ namespace cn
     std::shared_ptr<SendTransactionContext> context = std::make_shared<SendTransactionContext>();
     context->dustPolicy.dustThreshold = m_currency.defaultDustThreshold();
 
-    context->foundMoney = selectDepositTransfers(depositIds, context->selectedTransfers);
+    context->foundMoney = selectDepositsTransfers(depositIds, context->selectedTransfers);
     throwIf(context->foundMoney < fee, error::WRONG_AMOUNT);
 
     transactionId = m_transactionsCache.addNewTransaction(context->foundMoney, fee, std::string(), {}, 0, {});
@@ -314,7 +345,7 @@ namespace cn
 
     setSpendingTransactionToDeposits(transactionId, depositIds);
 
-    return doSendDepositWithdrawTransaction(std::move(context), events, depositIds);
+    return doSendDepositsWithdrawTransaction(std::move(context), events, depositIds);
   }
 
   std::shared_ptr<WalletRequest> WalletTransactionSender::makeSendFusionRequest(TransactionId &transactionId, std::deque<std::unique_ptr<WalletLegacyEvent>> &events,
@@ -532,7 +563,7 @@ namespace cn
 
       std::vector<DepositId> deposits{depositId};
 
-      return std::unique_ptr<WalletRequest>(new WalletRelayDepositTransactionRequest(lowlevelTransaction, std::bind(&WalletTransactionSender::relayDepositTransactionCallback, this, context,
+      return std::unique_ptr<WalletRequest>(new WalletRelayDepositTransactionRequest(lowlevelTransaction, std::bind(&WalletTransactionSender::relayDepositsTransactionCallback, this, context,
                                                                                                                     deposits, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)));
     }
     catch (std::system_error &ec)
@@ -548,6 +579,71 @@ namespace cn
   }
 
   std::unique_ptr<WalletRequest> WalletTransactionSender::doSendDepositWithdrawTransaction(std::shared_ptr<SendTransactionContext> &&context,
+                                                                                           std::deque<std::unique_ptr<WalletLegacyEvent>> &events, const DepositId &depositId)
+  {
+    if (m_isStoping)
+    {
+      events.push_back(makeCompleteEvent(m_transactionsCache, context->transactionId, make_error_code(error::TX_CANCELLED)));
+      return std::unique_ptr<WalletRequest>();
+    }
+
+    try
+    {
+      WalletLegacyTransaction &transactionInfo = m_transactionsCache.getTransaction(context->transactionId);
+
+      std::unique_ptr<ITransaction> transaction = createTransaction();
+      std::vector<MultisignatureInput> inputs = prepareMultisignatureInputs(context->selectedTransfers);
+
+      std::vector<uint64_t> outputAmounts = splitAmount(context->foundMoney - transactionInfo.fee, context->dustPolicy.dustThreshold);
+
+      for (const auto &input : inputs)
+      {
+        transaction->addInput(input);
+      }
+
+      for (auto amount : outputAmounts)
+      {
+        transaction->addOutput(amount, m_keys.address);
+      }
+
+      transaction->setUnlockTime(transactionInfo.unlockTime);
+
+      assert(inputs.size() == context->selectedTransfers.size());
+      for (size_t i = 0; i < inputs.size(); ++i)
+      {
+        transaction->signInputMultisignature(i, context->selectedTransfers[i].transactionPublicKey, context->selectedTransfers[i].outputInTransaction, m_keys);
+      }
+
+      transactionInfo.hash = transaction->getTransactionHash();
+
+      Transaction lowlevelTransaction = convertTransaction(*transaction, static_cast<size_t>(m_upperTransactionSizeLimit));
+
+      uint64_t interestsSum;
+      uint64_t totalSum;
+      countDepositTotalSumAndInterestSum(depositId, m_transactionsCache, totalSum, interestsSum);
+
+      UnconfirmedSpentDepositDetails unconfirmed;
+      unconfirmed.depositsSum = totalSum;
+      unconfirmed.fee = transactionInfo.fee;
+      unconfirmed.transactionId = context->transactionId;
+      m_transactionsCache.addDepositSpendingTransaction(transaction->getTransactionHash(), unconfirmed);
+
+      return std::unique_ptr<WalletRelayDepositTransactionRequest>(new WalletRelayDepositTransactionRequest(lowlevelTransaction,
+                                                                                                            std::bind(&WalletTransactionSender::relayDepositTransactionCallback, this, context, depositId, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)));
+    }
+    catch (std::system_error &ec)
+    {
+      events.push_back(makeCompleteEvent(m_transactionsCache, context->transactionId, ec.code()));
+    }
+    catch (std::exception &)
+    {
+      events.push_back(makeCompleteEvent(m_transactionsCache, context->transactionId, make_error_code(error::INTERNAL_WALLET_ERROR)));
+    }
+
+    return std::unique_ptr<WalletRequest>();
+  }
+
+  std::unique_ptr<WalletRequest> WalletTransactionSender::doSendDepositsWithdrawTransaction(std::shared_ptr<SendTransactionContext> &&context,
                                                                                            std::deque<std::unique_ptr<WalletLegacyEvent>> &events, const std::vector<DepositId> &depositIds)
   {
     if (m_isStoping)
@@ -598,7 +694,7 @@ namespace cn
       m_transactionsCache.addDepositSpendingTransaction(transaction->getTransactionHash(), unconfirmed);
 
       return std::unique_ptr<WalletRelayDepositTransactionRequest>(new WalletRelayDepositTransactionRequest(lowlevelTransaction,
-                                                                                                            std::bind(&WalletTransactionSender::relayDepositTransactionCallback, this, context, depositIds, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)));
+                                                                                                            std::bind(&WalletTransactionSender::relayDepositsTransactionCallback, this, context, depositIds, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3)));
     }
     catch (std::system_error &ec)
     {
@@ -624,6 +720,21 @@ namespace cn
   }
 
   void WalletTransactionSender::relayDepositTransactionCallback(std::shared_ptr<SendTransactionContext> context,
+                                                                DepositId deposit,
+                                                                std::deque<std::unique_ptr<WalletLegacyEvent>> &events,
+                                                                std::unique_ptr<WalletRequest> &nextRequest,
+                                                                std::error_code ec)
+  {
+    if (m_isStoping)
+    {
+      return;
+    }
+
+    events.push_back(makeCompleteEvent(m_transactionsCache, context->transactionId, ec));
+    events.push_back(std::unique_ptr<WalletDepositUpdatedEvent>(new WalletDepositUpdatedEvent(deposit)));
+  }
+
+  void WalletTransactionSender::relayDepositsTransactionCallback(std::shared_ptr<SendTransactionContext> context,
                                                                 std::vector<DepositId> deposits,
                                                                 std::deque<std::unique_ptr<WalletLegacyEvent>> &events,
                                                                 std::unique_ptr<WalletRequest> &nextRequest,
@@ -902,7 +1013,32 @@ namespace cn
     return foundMoney;
   }
 
-  uint64_t WalletTransactionSender::selectDepositTransfers(const std::vector<DepositId> &depositIds, std::vector<TransactionOutputInformation> &selectedTransfers)
+  uint64_t WalletTransactionSender::selectDepositTransfers(const DepositId &depositId, std::vector<TransactionOutputInformation> &selectedTransfers)
+  {
+    uint64_t foundMoney = 0;
+    
+    Hash transactionHash;
+    uint32_t outputInTransaction;
+    throwIf(m_transactionsCache.getDepositInTransactionInfo(depositId, transactionHash, outputInTransaction) == false, error::DEPOSIT_DOESNOT_EXIST);
+    
+    {
+      TransactionOutputInformation transfer;
+      ITransfersContainer::TransferState state;
+      throwIf(m_transferDetails.getTransfer(transactionHash, outputInTransaction, transfer, state) == false, error::DEPOSIT_DOESNOT_EXIST);
+      throwIf(state != ITransfersContainer::TransferState::TransferAvailable, error::DEPOSIT_LOCKED);
+      selectedTransfers.push_back(std::move(transfer));
+    }
+
+    Deposit deposit;
+    bool r = m_transactionsCache.getDeposit(depositId, deposit);
+    assert(r);
+
+    foundMoney += deposit.amount + deposit.interest;
+
+    return foundMoney;
+  }
+
+  uint64_t WalletTransactionSender::selectDepositsTransfers(const std::vector<DepositId> &depositIds, std::vector<TransactionOutputInformation> &selectedTransfers)
   {
     uint64_t foundMoney = 0;
 
@@ -928,6 +1064,12 @@ namespace cn
     }
 
     return foundMoney;
+  }
+
+  void WalletTransactionSender::setSpendingTransactionToDeposit(TransactionId transactionId, const DepositId &depositId)
+  {
+    Deposit &deposit = m_transactionsCache.getDeposit(depositId);
+    deposit.spendingTransactionId = transactionId;
   }
 
   void WalletTransactionSender::setSpendingTransactionToDeposits(TransactionId transactionId, const std::vector<DepositId> &depositIds)

--- a/src/WalletLegacy/WalletTransactionSender.h
+++ b/src/WalletLegacy/WalletTransactionSender.h
@@ -50,9 +50,14 @@ public:
 
   std::unique_ptr<WalletRequest> makeWithdrawDepositRequest(TransactionId& transactionId,
                                                             std::deque<std::unique_ptr<WalletLegacyEvent>>& events,
+                                                            const DepositId& depositId,
+                                                            uint64_t fee);
+
+  std::unique_ptr<WalletRequest> makeWithdrawDepositsRequest(TransactionId& transactionId,
+                                                            std::deque<std::unique_ptr<WalletLegacyEvent>>& events,
                                                             const std::vector<DepositId>& depositIds,
                                                             uint64_t fee);
-                                                            
+
 std::shared_ptr<WalletRequest> makeSendFusionRequest(TransactionId& transactionId, std::deque<std::unique_ptr<WalletLegacyEvent>>& events,
                                                      const std::vector<WalletLegacyTransfer>& transfers, const std::list<TransactionOutputInformation>& fusionInputs,
                                                      uint64_t fee, const std::string& extra = "", uint64_t mixIn = 0, uint64_t unlockTimestamp = 0);
@@ -62,6 +67,9 @@ private:
   std::unique_ptr<WalletRequest> doSendTransaction(std::shared_ptr<SendTransactionContext>&& context, std::deque<std::unique_ptr<WalletLegacyEvent>>& events, crypto::SecretKey& transactionSK);
   std::unique_ptr<WalletRequest> doSendMultisigTransaction(std::shared_ptr<SendTransactionContext>&& context, std::deque<std::unique_ptr<WalletLegacyEvent>>& events);
   std::unique_ptr<WalletRequest> doSendDepositWithdrawTransaction(std::shared_ptr<SendTransactionContext>&& context,
+                                                                  std::deque<std::unique_ptr<WalletLegacyEvent>>& events,
+                                                                  const DepositId& depositId);
+  std::unique_ptr<WalletRequest> doSendDepositsWithdrawTransaction(std::shared_ptr<SendTransactionContext>&& context,
                                                                   std::deque<std::unique_ptr<WalletLegacyEvent>>& events,
                                                                   const std::vector<DepositId>& depositIds);
 
@@ -90,6 +98,11 @@ private:
                                 std::unique_ptr<WalletRequest>& nextRequest,
                                 std::error_code ec);
   void relayDepositTransactionCallback(std::shared_ptr<SendTransactionContext> context,
+                                       DepositId deposit,
+                                       std::deque<std::unique_ptr<WalletLegacyEvent>>& events,
+                                       std::unique_ptr<WalletRequest>& nextRequest,
+                                       std::error_code ec);
+  void relayDepositsTransactionCallback(std::shared_ptr<SendTransactionContext> context,
                                        std::vector<DepositId> deposits,
                                        std::deque<std::unique_ptr<WalletLegacyEvent>>& events,
                                        std::unique_ptr<WalletRequest>& nextRequest,
@@ -101,8 +114,10 @@ private:
 
   uint64_t selectNTransfersToSend(std::vector<TransactionOutputInformation>& selectedTransfers);
   uint64_t selectTransfersToSend(uint64_t neededMoney, bool addDust, uint64_t dust, std::vector<TransactionOutputInformation>& selectedTransfers);
-  uint64_t selectDepositTransfers(const std::vector<DepositId>& depositIds, std::vector<TransactionOutputInformation>& selectedTransfers);
+  uint64_t selectDepositTransfers(const DepositId& depositId, std::vector<TransactionOutputInformation>& selectedTransfers);
+  uint64_t selectDepositsTransfers(const std::vector<DepositId>& depositIds, std::vector<TransactionOutputInformation>& selectedTransfers);
 
+  void setSpendingTransactionToDeposit(TransactionId transactionId, const DepositId& depositId);
   void setSpendingTransactionToDeposits(TransactionId transactionId, const std::vector<DepositId>& depositIds);
 
   const Currency& m_currency;


### PR DESCRIPTION
### New commands
- `deposit <months> <amount>` - Creates a HLTC by depositing $CCX
- `withdraw <id>` - Withdraws banked $CCX
- `list_deposits [block_height>` - Lists all known deposits in this wallet, optionally from a certain block height

### Notes
- **Do not try and deposit more coins than what you can afford to loose**, these are new features to the wallet and it does need fully testing before merge, after merge, deposit all the coins to your hearts content
- `deposit()` might look like it belongs to the `TransferCommand` struct but as only 2 args are needed (term + amount), with none being optional, we don't use this struct, assign the args and use them as is
- https://github.com/ConcealNetwork/conceal-core/commit/a637768756d7da3bfeaf0e60ddc9bf6d6ba534bc doesn't replace the base function, this is merely just a copied function but we don't use `std::vector<DepositID>`, only `DepositID` used in `concealwallet`'s `withdraw` command
- I sort of rushed `printListDepositsItem()` so this will need looking at, I copied the same logic as `list_transfers` only we don't timestamp each deposit. ALSO, line #577 SimpleWallet.cpp, how it says `"Term: "`, should I change this to `"Months: " = term / 21900` to keep it consistent regarding the term (the wallet refers to terms as months for the users sake, allowing them to easily track 1-12 rather than term % 21900 