### PR TITLE
Development

### DIFF
--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -1118,7 +1118,7 @@ std::unique_ptr<IBlock> core::getBlock(const crypto::Hash& blockId) {
     return std::unique_ptr<BlockWithTransactions>(nullptr);
   }
 
-  return std::move(blockPtr);
+  return blockPtr;
 }
 
 bool core::is_key_image_spent(const crypto::KeyImage& key_im) {

--- a/src/PaymentGate/WalletService.cpp
+++ b/src/PaymentGate/WalletService.cpp
@@ -1141,7 +1141,6 @@ namespace payment_service
         spendingTransactionHash = common::podToHex(walletstx.hash);
       }
 
-      bool state = true;
       uint32_t knownBlockCount = node.getKnownBlockCount();
       if (knownBlockCount > unlockHeight)
       {
@@ -1451,6 +1450,12 @@ namespace payment_service
                                                              addr,
                                                              address_str);
 
+    if (!valid)
+    {
+      logger(logging::ERROR) << "Failed to parse address!";
+      return make_error_code(cn::error::BAD_ADDRESS);
+    }
+
     cn::BinaryArray ba;
     cn::toBinaryArray(addr, ba);
     std::string keys = common::asString(ba);
@@ -1647,7 +1652,6 @@ namespace payment_service
     {
       platform_system::EventLock lk(readyEvent);
 
-      auto estimateResult = fusionManager.estimate(1000000, {});
       knownBlockCount = node.getKnownBlockCount();
       peerCount = static_cast<uint32_t>(node.getPeerCount());
       blockCount = wallet.getBlockCount();

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -629,9 +629,6 @@ bool RpcServer::k_on_check_tx_proof(const K_COMMAND_RPC_CHECK_TX_PROOF::request&
       throw JsonRpc::JsonRpcError{ CORE_RPC_ERROR_CODE_INTERNAL_ERROR, "Failed to generate key derivation" };
     }
 
-    // get tx pub key
-		crypto::PublicKey txPubKey = getTransactionPublicKeyFromExtra(transaction.extra);
-
 		// look for outputs
 		uint64_t received(0);
 		size_t keyIndex(0);

--- a/src/Wallet/PoolRpcServer.cpp
+++ b/src/Wallet/PoolRpcServer.cpp
@@ -345,6 +345,11 @@ bool pool_rpc_server::on_create_integrated(const wallet_rpc::COMMAND_RPC_CREATE_
     const bool valid = cn::parseAccountAddressString(prefix, 
                                                             addr,
                                                             address_str);
+    if (!valid)
+    {
+      logger(logging::ERROR) << "Failed to parse address!";
+      return false;
+    }
 
     cn::BinaryArray ba;
     cn::toBinaryArray(addr, ba);

--- a/src/Wallet/PoolRpcServer.cpp
+++ b/src/Wallet/PoolRpcServer.cpp
@@ -348,7 +348,7 @@ bool pool_rpc_server::on_create_integrated(const wallet_rpc::COMMAND_RPC_CREATE_
     if (!valid)
     {
       logger(logging::ERROR) << "Failed to parse address!";
-      return false;
+      throw JsonRpc::JsonRpcError(cn::error::BAD_ADDRESS, "Failed to parse address!");
     }
 
     cn::BinaryArray ba;

--- a/src/Wallet/WalletRpcServer.cpp
+++ b/src/Wallet/WalletRpcServer.cpp
@@ -483,6 +483,12 @@ bool wallet_rpc_server::on_create_integrated(const wallet_rpc::COMMAND_RPC_CREAT
                                                             addr,
                                                             address_str);
 
+    if (!valid)
+    {
+      /* throw or return false? */
+      throw JsonRpc::JsonRpcError(cn::error::BAD_ADDRESS, std::string("Failed to parse address!"));
+    }
+
     cn::BinaryArray ba;
     cn::toBinaryArray(addr, ba);
     std::string keys = common::asString(ba);

--- a/src/Wallet/WalletRpcServer.cpp
+++ b/src/Wallet/WalletRpcServer.cpp
@@ -8,6 +8,7 @@
 #include "WalletRpcServer.h"
 
 #include <fstream>
+
 #include "Common/CommandLine.h"
 #include "Common/StringTools.h"
 #include "CryptoNoteCore/CryptoNoteFormatUtils.h"

--- a/src/Wallet/WalletRpcServer.cpp
+++ b/src/Wallet/WalletRpcServer.cpp
@@ -485,8 +485,8 @@ bool wallet_rpc_server::on_create_integrated(const wallet_rpc::COMMAND_RPC_CREAT
 
     if (!valid)
     {
-      /* throw or return false? */
-      throw JsonRpc::JsonRpcError(cn::error::BAD_ADDRESS, std::string("Failed to parse address!"));
+      logger(logging::ERROR) << "Failed to parse address!";
+      throw JsonRpc::JsonRpcError(cn::error::BAD_ADDRESS, "Failed to parse address!");
     }
 
     cn::BinaryArray ba;

--- a/src/WalletLegacy/WalletLegacy.cpp
+++ b/src/WalletLegacy/WalletLegacy.cpp
@@ -616,8 +616,11 @@ size_t WalletLegacy::estimateFusion(const uint64_t& threshold) {
   bucketSizes.fill(0);
   for (auto& out : outputs) {
     uint8_t powerOfTen = 0;
-    assert(powerOfTen < std::numeric_limits<uint64_t>::digits10 + 1);
-    bucketSizes[powerOfTen]++;
+    if (m_currency.isAmountApplicableInFusionTransactionInput(out.amount, threshold, powerOfTen, m_node.getLastKnownBlockHeight()))
+    {
+      assert(powerOfTen < std::numeric_limits<uint64_t>::digits10 + 1);
+      bucketSizes[powerOfTen]++;
+    }
   }
   for (auto bucketSize : bucketSizes) {
     if (bucketSize >= m_currency.fusionTxMinInputCount()) {

--- a/src/WalletLegacy/WalletTransactionSender.cpp
+++ b/src/WalletLegacy/WalletTransactionSender.cpp
@@ -135,22 +135,6 @@ namespace
     return result;
   }
 
-  uint64_t checkDepositsAndCalculateAmount(const std::vector<DepositId> &depositIds, const WalletUserTransactionsCache &transactionsCache)
-  {
-    uint64_t amount = 0;
-
-    for (const auto &id : depositIds)
-    {
-      Deposit deposit;
-      throwIf(!transactionsCache.getDeposit(id, deposit), error::DEPOSIT_DOESNOT_EXIST);
-      throwIf(deposit.locked, error::DEPOSIT_LOCKED);
-
-      amount += deposit.amount + deposit.interest;
-    }
-
-    return amount;
-  }
-
   void countDepositTotalSumAndInterestSum(const DepositId &depositId, WalletUserTransactionsCache &depositsCache,
                                            uint64_t &totalSum, uint64_t &interestsSum)
   {


### PR DESCRIPTION
* removed redundant `std::move(blockPtr)` call
* removed unused vars from `WalletService`
* check if wallet is valid in `WalletService`, `PoolRpcServer` & `WalletRpcServer`
* remove unneeded `txPubKey` in RpcServer: we get this already from `#L613` which is also checked to see if its NULL
* make use of `out` in `for()` statement in `WalletLegacy`
* removed unused function in `WalletTransactionSender`