### PR TITLE
README: Updated Dependencies & Other Stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In some build scenarios it may be necessary to increase the size of the SWAP to 
 
 For example if you have 8GB of RAM, then your SWAP size should be 5GB
 
--   Ubuntu / Linux
+-   Ubuntu / Debian
 
 ```bash
 sudo fallocate -l 5G /swapfile
@@ -67,20 +67,22 @@ sudo dphys-swapfile setup
 sudo dphys-swapfile swapon
 ```
 
-### Linux / Ubuntu / Debian
+### Linux
 
 #### Prerequisites
 
 -   You will need the following dependencies to build the Conceal CLI: boost, cmake, git, gcc, g++, python, and make:
 
+##### Ubuntu and Debian Based Systems
+
 ```bash
 sudo apt update
-sudo apt-get install -y build-essential python-dev gcc g++ git cmake libboost-all-dev
+sudo apt install -y build-essential python3-dev git cmake libboost-all-dev
 ```
 
 #### Building
 
--   On Ubuntu:
+-   On Linux Systems:
 
 ```bash
 git clone https://github.com/ConcealNetwork/conceal-core


### PR DESCRIPTION
### Removed redundant dependencies
Both GCC and G++ are included with the `build-essential` package, so including them in the dependency list (ie `apt install .....`) is redundant.

### Changed 'python-dev' to 'python3-dev'
On Ubuntu and Debian Based Systems, `python` refers to Python 2, and the package that is actually needed is named `python3-dev`. Attempting to install `python-dev` threw this error on Linux Mint 21:

```
Package python-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
 python2-dev:i386 python2:i386 python2-dev python2 python-dev-is-python3

E: Package 'python-dev' has no installation candidate
```


### Changed 'Ubuntu' to 'Linux'
Changed the header of 'Building/Ubuntu' to 'Building/Linux', as the commands there are pretty much identical across all distributions, so instead of it saying:

> On Ubuntu:

It now says

> On Linux Systems:

### `apt-get` is now `apt`
Changed `apt-get install` to `apt install`. Functions pretty much the same as `apt-get install`