### PR TITLE
GitHub Actions update

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -64,7 +64,7 @@ jobs:
           cp build/tests/Release/*_tests.exe build/conceal
 
       - name: Upload To GH Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.setup.outputs.release_name }}
           path: build/conceal
@@ -142,7 +142,7 @@ jobs:
           cp build/tests/*_tests.exe build/conceal
 
       - name: Upload To GH Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.setup.outputs.release_name }}
           path: build/conceal
@@ -211,7 +211,7 @@ jobs:
           cp build/tests/*_tests build/conceal
 
       - name: Upload To GH Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.setup.outputs.release_name }}
           path: build/conceal
@@ -281,7 +281,7 @@ jobs:
           cp build/tests/*_tests build/conceal
 
       - name: Upload To GH Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.setup.outputs.release_name }}
           path: build/conceal
@@ -351,7 +351,7 @@ jobs:
           cp build/tests/*_tests build/conceal
 
       - name: Upload To GH Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.setup.outputs.release_name }}
           path: build/conceal
@@ -420,7 +420,7 @@ jobs:
           cp build/tests/*_tests build/conceal
 
       - name: Upload To GH Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.setup.outputs.release_name }}
           path: build/conceal

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,7 +30,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.1.3
 
       - name: Restore Boost
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: restore-boost
         with:
           path: ${{env.BOOST_ROOT}}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,7 @@ jobs:
           echo "release_name=${release_name}" >> $env:GITHUB_OUTPUT
 
       - name: Install msbuild
-        uses: microsoft/setup-msbuild@v1.1.3
+        uses: microsoft/setup-msbuild@v2
 
       - name: Restore Boost
         uses: actions/cache@v4

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -36,7 +36,7 @@ jobs:
           echo "ccx_version=${ccx_version}" >> $GITHUB_OUTPUT
 
       - name: Create Release
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v2.0.4
         with:
           files: ${{ steps.build.outputs.asset_path }}
           name: Conceal Core CLI v${{ steps.build.outputs.ccx_version }}

--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -43,7 +43,7 @@ jobs:
           echo "ccx_version=${ccx_version}" >> $GITHUB_OUTPUT
 
       - name: Create Release
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v2.0.4
         with:
           files: ${{ steps.build.outputs.asset_path }}
           name: Conceal Core CLI v${{ steps.build.outputs.ccx_version }}

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -43,7 +43,7 @@ jobs:
           echo "ccx_version=${ccx_version}" >> $GITHUB_OUTPUT
 
       - name: Create Release
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v2.0.4
         with:
           files: ${{ steps.build.outputs.asset_path }}
           name: Conceal Core CLI v${{ steps.build.outputs.ccx_version }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.1.3
 
       - name: Restore Boost
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: restore-boost
         with:
           path: ${{env.BOOST_ROOT}}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,7 +55,7 @@ jobs:
           echo "ccx_version=${ccx_version}" >> $env:GITHUB_OUTPUT
 
       - name: Create Release
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v2.0.4
         with:
           files: ${{ steps.build.outputs.asset_path }}
           name: Conceal Core CLI v${{ steps.build.outputs.ccx_version }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Setup msbuild
-        uses: microsoft/setup-msbuild@v1.1.3
+        uses: microsoft/setup-msbuild@v2
 
       - name: Restore Boost
         uses: actions/cache@v4


### PR DESCRIPTION
Fix GitHub Actions warnings

- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/