### PR TITLE
implement memory-based object count limits for DDOS protection

### DIFF
--- a/src/CryptoNoteConfig.h
+++ b/src/CryptoNoteConfig.h
@@ -141,7 +141,14 @@ namespace cn
 		const char P2P_NET_DATA_FILENAME[] = "p2pstate.bin";
 		const char CRYPTONOTE_BLOCKCHAIN_INDICES_FILENAME[] = "blockchainindices.dat";
 		const char MINER_CONFIG_FILE_NAME[] = "miner_conf.json";
+		
+		// Memory management constants
+		const uint32_t ABSOLUTE_MAX_OBJECTS = 1200;     // can safely be handled memory wise, but a limiting factor to prevent DDOS attack
+		const uint32_t FALLBACK_MAX_OBJECTS = 800;     // Default when memory check fails
+		const uint64_t MIN_MEMORY_MB = 150;           // Minimum memory required for handling fallback max objects
 
+		// Memory management constants validation
+		static_assert(ABSOLUTE_MAX_OBJECTS > FALLBACK_MAX_OBJECTS, "Maximum object count must be greater than Fallback");
 	} // namespace parameters
 
 	const uint64_t START_BLOCK_REWARD = (UINT64_C(5000) * parameters::POINT);  // start reward (Consensus I)

--- a/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.h
+++ b/src/CryptoNoteProtocol/CryptoNoteProtocolHandler.h
@@ -8,9 +8,10 @@
 #pragma once
 
 #include <atomic>
+#include <cstdint>
 
 #include <Common/ObserverManager.h>
-
+#include "../CryptoNoteConfig.h"
 #include "CryptoNoteCore/ICore.h"
 
 #include "CryptoNoteProtocol/CryptoNoteProtocolDefinitions.h"
@@ -118,5 +119,9 @@ namespace cn
 
     std::atomic<size_t> m_peersCount;
     tools::ObserverManager<ICryptoNoteProtocolObserver> m_observerManager;
+
+    std::atomic<uint32_t> m_maxObjectCount;
+    uint64_t getAvailableMemory() const;
+    uint32_t calculateMaxObjectCount() const;
   };
 }


### PR DESCRIPTION
* Add cross-platform memory detection (Windows, Linux, macOS)
* Implement dynamic object limit calculation based on available memory
* Add fallback mechanism for low-memory systems
* Configure memory thresholds: 150MB minimum, 800 fallback, 1200 max objects
* Prevent memory exhaustion attacks and improve system stability
* Add proper error handling and logging for memory operations