### PR TITLE
fix(system,wallet): stop aborting on benign remoteSpawn EAGAIN; fix deleteAddress use-after-free

### DIFF
--- a/src/Platform/Linux/System/Dispatcher.cpp
+++ b/src/Platform/Linux/System/Dispatcher.cpp
@@ -19,6 +19,7 @@
 
 #include <System/ErrorMessage.h>
 #include <cassert>
+#include <cerrno>
 #include <fcntl.h>
 #include <stdexcept>
 #include <string.h>
@@ -182,7 +183,11 @@ void Dispatcher::dispatch() {
       if(((event.events & (EPOLLIN | EPOLLOUT)) != 0) && contextPair->readContext == nullptr && contextPair->writeContext == nullptr) {
         uint64_t buf;
         auto transferred = read(remoteSpawnEvent, &buf, sizeof buf);
-        if(transferred == -1) {
+        // The remoteSpawnEvent is a level-triggered, O_NONBLOCK eventfd drained from both
+        // dispatch() and yield(); a concurrent drain can make this read() return EAGAIN/EWOULDBLOCK
+        // (errno 11). That is benign (queued procedures are still drained under the mutex below), so
+        // treat it as "already drained" instead of aborting the process.
+        if(transferred == -1 && errno != EAGAIN && errno != EWOULDBLOCK) {
             throw std::runtime_error("Dispatcher::dispatch, read(remoteSpawnEvent) failed, " + lastErrorMessage());
         }
 
@@ -311,8 +316,12 @@ void Dispatcher::yield() {
         if(((events[i].events & (EPOLLIN | EPOLLOUT)) != 0) && contextPair->readContext == nullptr && contextPair->writeContext == nullptr) {
           uint64_t buf;
           auto transferred = read(remoteSpawnEvent, &buf, sizeof buf);
-          if(transferred == -1) {
-            throw std::runtime_error("Dispatcher::dispatch, read(remoteSpawnEvent) failed, " + lastErrorMessage());
+          // The remoteSpawnEvent is a level-triggered, O_NONBLOCK eventfd drained from both
+          // dispatch() and yield(); a concurrent drain can make this read() return EAGAIN/EWOULDBLOCK
+          // (errno 11). That is benign (queued procedures are still drained under the mutex below), so
+          // treat it as "already drained" instead of aborting the process.
+          if(transferred == -1 && errno != EAGAIN && errno != EWOULDBLOCK) {
+            throw std::runtime_error("Dispatcher::yield, read(remoteSpawnEvent) failed, " + lastErrorMessage());
           }
 
           MutextGuard guard(*reinterpret_cast<pthread_mutex_t*>(this->mutex));

--- a/src/Wallet/WalletGreen.cpp
+++ b/src/Wallet/WalletGreen.cpp
@@ -1682,10 +1682,12 @@ namespace cn
     std::vector<size_t> updatedTransactions = deleteTransfersForAddress(address, deletedTransactions);
     deleteFromUncommitedTransactions(deletedTransactions);
 
-    m_walletsContainer.get<KeysIndex>().erase(it);
-
+    // Compute the random-access position BEFORE erasing: erase() frees the node `it` refers to, so
+    // project<>(it) and std::distance() must run while `it` is still valid (else heap-use-after-free).
     auto addressIndex = std::distance(
         m_walletsContainer.get<RandomAccessIndex>().begin(), m_walletsContainer.project<RandomAccessIndex>(it));
+
+    m_walletsContainer.get<KeysIndex>().erase(it);
 
     m_containerStorage.erase(std::next(m_containerStorage.begin(), addressIndex));
 


### PR DESCRIPTION
## What

Two pre-existing, ASan-root-caused crashes in the daemon/wallet runtime, each a narrow, backward-compatible fix. No consensus, serialization, or wire-format surface is touched.

### 1. `Dispatcher` aborts the process on a benign `remoteSpawnEvent` `EAGAIN`

`src/Platform/Linux/System/Dispatcher.cpp`

`remoteSpawnEvent` is a level-triggered, `O_NONBLOCK` `eventfd` that is drained from **both** `Dispatcher::dispatch()` and `Dispatcher::yield()`. A level-triggered `EPOLLIN` can be observed by two `epoll_wait()` calls, so the second `read()` of the already-drained fd returns `-1` with `EAGAIN`/`EWOULDBLOCK` (errno 11).

The old code treated **any** `read() == -1` as fatal and threw `std::runtime_error`. Thrown out of the dispatch loop, that unwinds into noexcept territory and ends the process via `std::terminate` — an intermittent crash under load.

Both drain sites now ignore `EAGAIN`/`EWOULDBLOCK` as a benign "already drained" condition (any other error still throws). The queued procedures are still drained under the mutex immediately below the read, so no wakeup is lost.

### 2. `WalletGreen::deleteAddress` heap-use-after-free

`src/Wallet/WalletGreen.cpp`

`deleteAddress()` erased the entry from the `KeysIndex` and **only afterwards** computed its random-access position via `project<RandomAccessIndex>(it)` + `std::distance()`. `erase()` frees the `boost::multi_index` node that `it` refers to, so using `it` after the erase is a heap-use-after-free (the freed `addressIndex` then drives `m_containerStorage.erase`).

The random-access index is now computed while `it` is still valid, before the erase. Same observable behavior, no dangling iterator.

## Why

Found while running the suite under AddressSanitizer: (1) manifested as an intermittent `std::terminate` from the dispatcher under load; (2) as a clean ASan heap-use-after-free report in `deleteAddress`. Both are latent on every platform — the dispatcher abort is Linux-path-specific, the UAF is platform-independent.

## How verified

- Built `-DBUILD_TESTS=ON` on Linux x86_64 (Ubuntu 24.04).
- `SystemTests` (exercises the dispatcher) — green.
- `UnitTests` (exercises `WalletGreen`) — green under the repo's baked-in skip filter.
- Re-ran the previously-flaky paths under ASan — no `terminate`, no use-after-free.

## Scope / risk

- 2 files, runtime-only. No change to `CryptoNoteConfig.h`, validation, difficulty, serialization, P2P, or checkpoints — **not a consensus change**.
- C++11, matches surrounding legacy style. Added `#include <cerrno>` for `errno`.
- Targets `development` per `CONTRIBUTING.md`.
