### PR TITLE
Development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# AGENTS.md
+
+## Purpose
+This repository must keep implementation, planning, and documentation aligned at all times.
+
+## Core rule
+Whenever code, architecture, roadmap, PQ strategy, benchmarks, storage design, consensus behavior, wallet/RPC behavior, build steps, or operational procedures change, review the `docs/` directory and update existing documentation or append new documentation before considering the task complete.
+
+## Documentation sync policy
+For every meaningful change, the agent must:
+
+1. Inspect `docs/` for an existing relevant document.
+2. Prefer updating an existing doc instead of creating a duplicate.
+3. Create a new doc only when no existing doc covers the change.
+4. Update cross-references when a renamed concept, flow, or decision affects multiple documents.
+5. Keep code and docs consistent in terminology, filenames, feature names, and status.
+
+## Required doc checks
+The agent must check whether the change affects any of these:
+- Architecture or component boundaries
+- PQ migration strategy or cryptographic choices
+- Benchmarks, measurements, or performance claims
+- Build, test, deployment, or developer workflow
+- Wallet, daemon, RPC, or database behavior
+- Config flags, CLI options, env vars, or defaults
+- Risk, tradeoff, compatibility, or rollout guidance
+- Roadmap, milestone, or decision status
+
+## Required actions on change
+When a relevant change is made, the agent must:
+- Update the affected document in `docs/`
+- Add a short “last updated because” note in the changed doc or changelog section
+- Preserve historical context for major decisions instead of overwriting it silently
+- Mark outdated assumptions as superseded
+- Add TODO markers only when the missing information is genuinely unknown
+
+## Completion gate
+A task is not complete until:
+- Code and docs are consistent
+- Any impacted file in `docs/` has been reviewed
+- New behavior or decisions are documented
+- Stale statements are corrected or removed
+
+## Preferred documentation behavior
+- Append incremental findings to the most relevant existing document
+- Use concise technical prose
+- Record rationale, not just outcome
+- Link implementation files, PRs, issues, benchmarks, or design notes when available
+- Do not invent benchmark values or claim a decision is final unless the source task says so
+
+## If no docs update is needed
+The agent must explicitly state:
+“No documentation update required after reviewing docs/, because ...”
+and give a one-sentence reason.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,133 @@
+# Conceal PQ Decisions Log
+
+Status: Active
+Maintainers: Conceal contributors working on post-quantum planning, architecture, benchmarking, and implementation
+Scope: Decision tracking for Conceal post-quantum research, migration strategy, and implementation work
+
+## How to use this file
+
+Use this file to record major technical and strategic decisions related to Conceal post-quantum work.
+
+Create a new entry whenever the team changes or confirms:
+- PQ scheme direction
+- Hybrid versus full migration approach
+- Signature, KEM, or key-management strategy
+- Benchmark-driven selection criteria
+- Wallet, daemon, RPC, or storage implications
+- Compatibility, rollout, fallback, or deprecation policy
+- Architecture decisions with multi-file or multi-component impact
+
+Guidelines:
+- Prefer appending new entries over overwriting history
+- If a decision changes, mark the old one as superseded
+- Keep entries concise but explicit about rationale and consequences
+- Link related docs, issues, PRs, benchmarks, or design notes whenever available
+
+## Entry template
+
+---
+
+### DEC-XXXX: Short decision title
+
+- Date: YYYY-MM-DD
+- Status: Proposed | Accepted | Deferred | Superseded | Rejected
+- Owners: @handle, @handle
+- Related work: issue/PR/doc links
+- Supersedes: DEC-XXXX or none
+- Superseded by: DEC-XXXX or none
+
+#### Context
+
+Describe the technical, strategic, or operational situation that required a decision.
+
+#### Decision
+
+State the decision clearly and directly.
+
+#### Rationale
+
+Explain why this option was chosen over alternatives.
+
+#### Consequences
+
+List the expected effects on implementation, planning, benchmarks, operations, or contributor workflow.
+
+#### Compatibility impact
+
+State the expected effect on backward compatibility, mixed deployments, migration, or external interfaces.
+
+#### Evidence
+
+Reference benchmarks, research notes, prototype results, or linked design material.
+
+#### Open questions
+
+List unresolved items that could change follow-on work.
+
+#### Documentation impact
+
+List which files in `docs/` should be updated because of this decision.
+
+---
+
+## Suggested tags
+
+Use these tags inside entries when helpful:
+- `PQ-schemes`
+- `hybrid-migration`
+- `benchmarks`
+- `wallet`
+- `daemon`
+- `rpc`
+- `storage`
+- `consensus-assumptions`
+- `compatibility`
+- `rollout`
+- `security`
+
+## Example entry
+
+---
+
+### DEC-0001: Record benchmark gate before narrowing PQ candidates
+
+- Date: 2026-07-15
+- Status: Proposed
+- Owners: @team
+- Related work: pq-conceal benchmark notes, scheme evaluation docs
+- Supersedes: none
+- Superseded by: none
+
+#### Context
+
+Multiple post-quantum candidate paths may remain viable until benchmark data is collected across the daemon, wallet, and transaction-critical flows.
+
+#### Decision
+
+Do not finalize a preferred PQ candidate set until benchmark criteria and test conditions are documented and repeatable.
+
+#### Rationale
+
+A scheme choice made before consistent measurements are available could optimize for incomplete assumptions and force rework later.
+
+#### Consequences
+
+Benchmark definitions become a gating deliverable for strategy updates, implementation sequencing, and documentation claims.
+
+#### Compatibility impact
+
+No immediate compatibility change, but future rollout planning should treat benchmark outcomes as a decision dependency.
+
+#### Evidence
+
+Link benchmark plans, prototype measurements, and evaluation dashboards.
+
+#### Open questions
+
+Which transaction paths, key sizes, verification costs, and storage impacts must be measured first?
+
+#### Documentation impact
+
+Update benchmark docs, migration planning docs, and any decision dashboard that references candidate narrowing.
+
+---

--- a/docs/wallet-shutdown-threading.md
+++ b/docs/wallet-shutdown-threading.md
@@ -1,0 +1,61 @@
+# WalletGreen shutdown and dispatcher threading
+
+Status: Implemented (2026-07-15, short-term roadmap item PR 1a)
+Scope: `src/Wallet/WalletGreen`, `src/Platform/{Linux,OSX,Windows}/System/Dispatcher`
+
+## Context
+
+`WalletGreen::shutdown()` and `~WalletGreen()` used to end with a raw
+`m_dispatcher.yield()` ("let remote spawns finish"). `Dispatcher` is
+single-threaded by design: every call except `remoteSpawn()` is only legal on
+the thread that constructed and pumps the dispatcher.
+
+conceal-desktop closes the wallet from the GUI thread
+(`WalletAdapter::close()` → `m_wallet.reset()`), while the node thread pumps
+the same dispatcher inside the node's `init()` loop. Calling `yield()` from
+the GUI thread raced the node thread on the same epoll/kqueue/IOCP event loop
+and could hang the UI or corrupt dispatcher state on wallet close.
+
+## Current design
+
+- Each platform `Dispatcher` records its owning thread at construction and
+  exposes `bool isOwnerThread() const`. On Windows this reuses the existing
+  `threadId` member (which yield/dispatch already assert on); Linux and macOS
+  gained an `m_ownerThreadId` member.
+- `WalletGreen::waitForRemoteSpawns()` (private) replaces the two raw
+  `yield()` call sites in `shutdown()` and the destructor:
+  - On the owner thread it still calls `yield()` — unchanged CLI/walletd
+    behavior.
+  - On a foreign thread it queues a barrier through `remoteSpawn()` (the only
+    thread-safe dispatcher entry point) and waits for the owner thread to
+    execute it. Once the barrier runs, every callback queued before shutdown
+    has executed and can no longer touch the destroyed wallet.
+  - The foreign-thread wait is bounded (10 s) so a dispatcher that is no
+    longer being pumped produces a logged warning instead of a permanent
+    freeze.
+
+## Rationale
+
+Draining is still required: pending `remoteSpawn` callbacks (for example from
+`synchronizationProgressUpdated`) capture `this` and would be a use-after-free
+if the wallet were destroyed before they run. The barrier gives the same
+guarantee as `yield()` without breaking the dispatcher's single-thread
+contract.
+
+This is distinct from the eventfd `EAGAIN`/`EINTR` fixes that landed with
+PR #360: those stopped a false-fatal abort in `dispatch()`/`yield()`; this
+change stops a cross-thread hang on wallet close.
+
+## Compatibility impact
+
+None on-protocol. `IWallet` API unchanged. conceal-desktop benefits without
+source changes; a follow-up in that repo can additionally make
+`WalletAdapter::close()` call `stop()`/`shutdown()` explicitly (matching the
+`WalletService` teardown order: `stop()` → wait → `shutdown()`).
+
+## Tests
+
+- `DispatcherTests.isOwnerThreadDetectsForeignThread`
+- `DispatcherTests.remoteSpawnFromForeignThreadRunsOnOwnerThread`
+- Full `system_tests` and CI-filtered `unit_tests` pass (the pre-existing
+  `WalletApi.shutdownInit` failure is unrelated and excluded from CI).

--- a/src/Platform/Linux/System/Dispatcher.cpp
+++ b/src/Platform/Linux/System/Dispatcher.cpp
@@ -312,6 +312,10 @@ void Dispatcher::spawn(std::function<void()>&& procedure) {
   pushContext(context);
 }
 
+bool Dispatcher::isOwnerThread() const {
+  return std::this_thread::get_id() == m_ownerThreadId;
+}
+
 void Dispatcher::yield() {
   for(;;){
     epoll_event events[16];

--- a/src/Platform/Linux/System/Dispatcher.h
+++ b/src/Platform/Linux/System/Dispatcher.h
@@ -22,6 +22,7 @@
 #include <functional>
 #include <queue>
 #include <stack>
+#include <thread>
 #ifndef __GLIBC__
 #include <bits/reg.h>
 #endif
@@ -76,6 +77,7 @@ public:
   void pushContext(NativeContext* context);
   void remoteSpawn(std::function<void()>&& procedure);
   void yield();
+  bool isOwnerThread() const;
 
   // system-dependent
   int getEpoll() const;
@@ -100,6 +102,9 @@ public:
 
 private:
   void spawn(std::function<void()>&& procedure);
+  // Thread that constructed (and therefore pumps) this dispatcher; every API
+  // except remoteSpawn() must only be called from it.
+  std::thread::id m_ownerThreadId = std::this_thread::get_id();
   int epoll;
   alignas(void*) uint8_t mutex[SIZEOF_PTHREAD_MUTEX_T];
   int remoteSpawnEvent;

--- a/src/Platform/OSX/System/Dispatcher.cpp
+++ b/src/Platform/OSX/System/Dispatcher.cpp
@@ -286,6 +286,10 @@ void Dispatcher::spawn(std::function<void()>&& procedure) {
   pushContext(context);
 }
 
+bool Dispatcher::isOwnerThread() const {
+  return std::this_thread::get_id() == m_ownerThreadId;
+}
+
 void Dispatcher::yield() {
   struct timespec zeroTimeout = { 0, 0 };
   int updatesCounter = 0;

--- a/src/Platform/OSX/System/Dispatcher.h
+++ b/src/Platform/OSX/System/Dispatcher.h
@@ -22,6 +22,7 @@
 #include <functional>
 #include <queue>
 #include <stack>
+#include <thread>
 
 namespace platform_system {
 
@@ -67,6 +68,7 @@ public:
   void pushContext(NativeContext* context);
   void remoteSpawn(std::function<void()>&& procedure);
   void yield();
+  bool isOwnerThread() const;
 
   int getKqueue() const;
   NativeContext& getReusableContext();
@@ -83,6 +85,9 @@ public:
 private:
   void spawn(std::function<void()>&& procedure);
 
+  // Thread that constructed (and therefore pumps) this dispatcher; every API
+  // except remoteSpawn() must only be called from it.
+  std::thread::id m_ownerThreadId = std::this_thread::get_id();
   int kqueue;
   int lastCreatedTimer;
   alignas(std::max_align_t) uint8_t mutex[SIZEOF_PTHREAD_MUTEX_T];

--- a/src/Platform/Windows/System/Dispatcher.cpp
+++ b/src/Platform/Windows/System/Dispatcher.cpp
@@ -272,6 +272,10 @@ void Dispatcher::spawn(std::function<void()>&& procedure) {
   pushContext(context);
 }
 
+bool Dispatcher::isOwnerThread() const {
+  return GetCurrentThreadId() == threadId;
+}
+
 void Dispatcher::yield() {
   assert(GetCurrentThreadId() == threadId);
   for (;;) {

--- a/src/Platform/Windows/System/Dispatcher.h
+++ b/src/Platform/Windows/System/Dispatcher.h
@@ -60,6 +60,7 @@ public:
   void pushContext(NativeContext* context);
   void remoteSpawn(std::function<void()>&& procedure);
   void yield();
+  bool isOwnerThread() const;
 
   // Platform-specific
   void addTimer(uint64_t time, NativeContext* context);

--- a/src/Wallet/WalletErrors.h
+++ b/src/Wallet/WalletErrors.h
@@ -77,7 +77,7 @@ public:
     case WRONG_PASSWORD:           return "The password is wrong";
     case ALREADY_INITIALIZED:      return "The object is already initialized";
     case INTERNAL_WALLET_ERROR:    return "Internal error occurred";
-    case MIXIN_COUNT_TOO_BIG:      return "MixIn count is too big";
+    case MIXIN_COUNT_TOO_BIG:      return "Not enough mixins available for selected outputs; wait for pending transactions to confirm, try again later";
     case NOTHING_TO_OPTIMIZE:      return "There are no inputs to optimize";
     case THRESHOLD_TOO_LOW:        return "Threshold must be greater than 10";    
     case MINIMUM_ONE_ADDRESS:      return "You should have at least one address";

--- a/src/Wallet/WalletGreen.cpp
+++ b/src/Wallet/WalletGreen.cpp
@@ -136,8 +136,25 @@ namespace
 
     if (notEnoughIt != mixinResult.end())
     {
-      throw std::system_error(make_error_code(cn::error::MIXIN_COUNT_TOO_BIG));
+      throw std::system_error(
+          make_error_code(cn::error::MIXIN_COUNT_TOO_BIG),
+          "amount=" + std::to_string(notEnoughIt->amount) +
+              " available=" + std::to_string(notEnoughIt->outs.size()) +
+              " required=" + std::to_string(mixIn));
     }
+  }
+
+  std::set<uint64_t> collectScarceMixinAmounts(const std::vector<outs_for_amount> &mixinResult, uint64_t mixIn)
+  {
+    std::set<uint64_t> scarce;
+    for (const auto &ofa : mixinResult)
+    {
+      if (ofa.outs.size() < mixIn)
+      {
+        scarce.insert(ofa.amount);
+      }
+    }
+    return scarce;
   }
 
   size_t getTransactionSize(const ITransactionReader &transaction)
@@ -443,22 +460,75 @@ namespace cn
 
     /* Select the wallet - If no source address was specified then it will pick funds from anywhere
      and the change will go to the primary address of the wallet container */
-    std::vector<WalletOuts> wallets;
-    wallets = pickWallets({sourceAddress});
+    std::vector<WalletOuts> wallets = pickWallets({sourceAddress});
 
-    /* Select the transfers */
+    /* Select transfers, skipping amounts that cannot be mixed */
     uint64_t fee = 1000;
     uint64_t neededMoney = amount + fee;
+    const uint64_t mixIn = cn::parameters::MINIMUM_MIXIN;
+    std::vector<WalletOuts> usableWallets = wallets;
     std::vector<OutputToTransfer> selectedTransfers;
-    uint64_t foundMoney = selectTransfers(neededMoney,
-                                          m_currency.defaultDustThreshold(),
-                                          wallets,
-                                          selectedTransfers);
+    std::vector<outs_for_amount> mixinResult;
+    uint64_t foundMoney = 0;
+    std::set<uint64_t> excludedAmounts;
 
-    /* Do we have enough funds */
-    if (foundMoney < neededMoney)
+    for (size_t attempt = 0;; ++attempt)
     {
-      throw std::system_error(make_error_code(error::WRONG_AMOUNT));
+      selectedTransfers.clear();
+      mixinResult.clear();
+      foundMoney = selectTransfers(neededMoney, m_currency.defaultDustThreshold(), usableWallets, selectedTransfers);
+
+      if (foundMoney < neededMoney)
+      {
+        if (!excludedAmounts.empty())
+        {
+          throw std::system_error(
+              make_error_code(error::MIXIN_COUNT_TOO_BIG),
+              "remaining outputs cannot satisfy required mixin");
+        }
+        throw std::system_error(make_error_code(error::WRONG_AMOUNT));
+      }
+
+      try
+      {
+        requestMixinOuts(selectedTransfers, mixIn, mixinResult);
+        break;
+      }
+      catch (const std::system_error &e)
+      {
+        if (e.code() != make_error_code(error::MIXIN_COUNT_TOO_BIG) || attempt >= 3)
+        {
+          throw;
+        }
+
+        auto scarce = collectScarceMixinAmounts(mixinResult, mixIn);
+        if (scarce.empty())
+        {
+          throw;
+        }
+
+        excludedAmounts.insert(scarce.begin(), scarce.end());
+        m_logger(WARNING, BRIGHT_YELLOW) << "Excluding " << scarce.size()
+                                         << " unmixable amount(s) and retrying deposit selection";
+
+        usableWallets.clear();
+        for (const auto &wallet : wallets)
+        {
+          WalletOuts copy;
+          copy.wallet = wallet.wallet;
+          for (const auto &out : wallet.outs)
+          {
+            if (excludedAmounts.count(out.amount) == 0)
+            {
+              copy.outs.push_back(out);
+            }
+          }
+          if (!copy.outs.empty())
+          {
+            usableWallets.emplace_back(std::move(copy));
+          }
+        }
+      }
     }
 
     /* Now we add the outputs to the transaction, starting with the deposits output
@@ -511,12 +581,8 @@ namespace cn
     transaction->setUnlockTime(0);
 
     /* Prepare the inputs */
-
-    /* Get additional inputs for the mixin */
-    std::vector<outs_for_amount> mixinResult;
-    requestMixinOuts(selectedTransfers, cn::parameters::MINIMUM_MIXIN, mixinResult);
     std::vector<InputInfo> keysInfo;
-    prepareInputs(selectedTransfers, mixinResult, cn::parameters::MINIMUM_MIXIN, keysInfo);
+    prepareInputs(selectedTransfers, mixinResult, mixIn, keysInfo);
 
     /* Add the inputs to the transaction */
     std::vector<KeyPair> ephKeys;
@@ -1995,19 +2061,74 @@ namespace cn
     preparedTransaction.destinations = convertOrdersToTransfers(orders);
     preparedTransaction.neededMoney = countNeededMoney(preparedTransaction.destinations, fee);
 
+    std::vector<WalletOuts> usableWallets = wallets;
     std::vector<OutputToTransfer> selectedTransfers;
-    uint64_t foundMoney = selectTransfers(preparedTransaction.neededMoney, m_currency.defaultDustThreshold(), wallets, selectedTransfers);
-
-    if (foundMoney < preparedTransaction.neededMoney)
-    {
-      throw std::system_error(make_error_code(error::WRONG_AMOUNT), "Not enough money");
-    }
-
     std::vector<outs_for_amount> mixinResult;
+    uint64_t foundMoney = 0;
+    std::set<uint64_t> excludedAmounts;
 
-    if (mixIn != 0)
+    for (size_t attempt = 0;; ++attempt)
     {
-      requestMixinOuts(selectedTransfers, mixIn, mixinResult);
+      selectedTransfers.clear();
+      mixinResult.clear();
+      foundMoney = selectTransfers(preparedTransaction.neededMoney, m_currency.defaultDustThreshold(), usableWallets, selectedTransfers);
+
+      if (foundMoney < preparedTransaction.neededMoney)
+      {
+        if (mixIn != 0 && !excludedAmounts.empty())
+        {
+          throw std::system_error(
+              make_error_code(error::MIXIN_COUNT_TOO_BIG),
+              "remaining outputs cannot satisfy required mixin");
+        }
+        throw std::system_error(make_error_code(error::WRONG_AMOUNT), "Not enough money");
+      }
+
+      if (mixIn == 0)
+      {
+        break;
+      }
+
+      try
+      {
+        requestMixinOuts(selectedTransfers, mixIn, mixinResult);
+        break;
+      }
+      catch (const std::system_error &e)
+      {
+        if (e.code() != make_error_code(error::MIXIN_COUNT_TOO_BIG) || attempt >= 3)
+        {
+          throw;
+        }
+
+        auto scarce = collectScarceMixinAmounts(mixinResult, mixIn);
+        if (scarce.empty())
+        {
+          throw;
+        }
+
+        excludedAmounts.insert(scarce.begin(), scarce.end());
+        m_logger(WARNING, BRIGHT_YELLOW) << "Excluding " << scarce.size()
+                                         << " unmixable amount(s) and retrying transfer selection";
+
+        usableWallets.clear();
+        for (const auto &wallet : wallets)
+        {
+          WalletOuts copy;
+          copy.wallet = wallet.wallet;
+          for (const auto &out : wallet.outs)
+          {
+            if (excludedAmounts.count(out.amount) == 0)
+            {
+              copy.outs.push_back(out);
+            }
+          }
+          if (!copy.outs.empty())
+          {
+            usableWallets.emplace_back(std::move(copy));
+          }
+        }
+      }
     }
 
     std::vector<InputInfo> keysInfo;
@@ -2846,18 +2967,21 @@ namespace cn
     auto getRandomOutsByAmountsCompleted = std::promise<std::error_code>();
     auto getRandomOutsByAmountsWaitFuture = getRandomOutsByAmountsCompleted.get_future();
 
-    m_node.getRandomOutsByAmounts(std::move(amounts), mixIn, mixinResult, [&getRandomOutsByAmountsCompleted](std::error_code ec) {
+    /* Request one extra so we can skip our own output if the daemon returns it
+       (same approach as WalletLegacy). Final ring size stays mixIn + 1 real. */
+    const uint64_t outsCount = mixIn + 1;
+    m_node.getRandomOutsByAmounts(std::move(amounts), outsCount, mixinResult, [&getRandomOutsByAmountsCompleted](std::error_code ec) {
       auto detachedPromise = std::move(getRandomOutsByAmountsCompleted);
       detachedPromise.set_value(ec);
     });
     std::error_code ec = getRandomOutsByAmountsWaitFuture.get();
 
-    checkIfEnoughMixins(mixinResult, mixIn);
-
     if (ec)
     {
       throw std::system_error(ec);
     }
+
+    checkIfEnoughMixins(mixinResult, mixIn);
   }
 
   uint64_t WalletGreen::selectTransfers(

--- a/src/Wallet/WalletGreen.cpp
+++ b/src/Wallet/WalletGreen.cpp
@@ -1369,6 +1369,11 @@ namespace cn
     m_extra = extra;
 
     m_state = WalletState::INITIALIZED;
+
+    /* Backfill unlock jobs for deposits saved before one was scheduled at their term
+       (or migrated from an older wallet file), then drain anything already past due. */
+    scheduleDepositUnlockJobs();
+
     m_logger(INFO, BRIGHT_WHITE) << "Container loaded, view public key " << common::podToHex(m_viewPublicKey) << ", wallet count " << m_walletsContainer.size() << ", actual balance " << m_currency.formatAmount(m_actualBalance) << ", pending balance " << m_currency.formatAmount(m_pendingBalance);
     m_observerManager.notify(&IWalletObserver::initCompleted, std::error_code());
   }
@@ -1979,8 +1984,12 @@ namespace cn
 
     Deposit deposit = m_deposits.get<RandomAccessIndex>()[depositIndex];
 
-    uint32_t knownBlockHeight = m_node.getLastKnownBlockHeight();
-    if (knownBlockHeight > deposit.unlockHeight)
+    /* Was m_node.getLastKnownBlockHeight(), the node's (possibly ahead-of-sync) height.
+       That could report a deposit unlocked before this wallet's own chain (getBlockCount(),
+       same source withdrawDeposit() and TransfersContainer/updateBalance() use) actually
+       reached unlockHeight, so "Unlocked" would show while withdraw still threw
+       DEPOSIT_LOCKED and the cached withdrawable balance was still 0. */
+    if (deposit.unlockHeight <= getBlockCount())
     {
       deposit.locked = false;
     }
@@ -3480,6 +3489,38 @@ namespace cn
     }
   }
 
+  /* Ordinary unlock jobs cover a transaction's own unlockTime/soft-lock, not deposit-term
+     maturity, so deposits saved before an unlock job existed for their term (or migrated
+     from an older wallet file) would never get updateBalance() re-run when they matured.
+     Schedule the missing job per unspent deposit, then drain anything already past due so
+     a reopened wallet immediately reflects deposits that matured while it was closed. */
+  void WalletGreen::scheduleDepositUnlockJobs()
+  {
+    for (DepositId id = 0; id < m_deposits.size(); ++id)
+    {
+      const Deposit &deposit = m_deposits.get<RandomAccessIndex>()[id];
+      if (deposit.spendingTransactionId != WALLET_INVALID_TRANSACTION_ID)
+      {
+        continue;
+      }
+
+      try
+      {
+        const std::string address = getTransactionTransfer(deposit.creatingTransactionId, 0).address;
+        insertUnlockTransactionJob(deposit.transactionHash, static_cast<uint32_t>(deposit.unlockHeight), getWalletRecord(address).container);
+      }
+      catch (const std::exception &)
+      {
+        continue;
+      }
+    }
+
+    if (getBlockCount() > 0)
+    {
+      unlockBalances(getBlockCount() - 1);
+    }
+  }
+
   void WalletGreen::onTransactionUpdated(ITransfersSubscription * /*object*/, const crypto::Hash & /*transactionHash*/)
   {
     // Deprecated, ignore it. New event handler is onTransactionUpdated(const crypto::PublicKey&, const crypto::Hash&, const std::vector<ITransfersContainer*>&)
@@ -3521,7 +3562,8 @@ namespace cn
       const TransactionOutputInformation &depositOutput,
       TransactionId creatingTransactionId,
       const Currency &currency,
-      uint32_t height)
+      uint32_t height,
+      cn::ITransfersContainer *container)
   {
     assert(depositOutput.type == transaction_types::OutputType::Multisignature);
     assert(depositOutput.term != 0);
@@ -3536,7 +3578,14 @@ namespace cn
     deposit.unlockHeight = height + depositOutput.term;
     deposit.locked = true;
 
-    return insertDeposit(deposit, depositOutput.outputInTransaction, depositOutput.transactionHash);
+    DepositId id = insertDeposit(deposit, depositOutput.outputInTransaction, depositOutput.transactionHash);
+
+    /* Ordinary unlock jobs only cover the transaction's own unlockTime/soft-lock;
+       schedule one for deposit-term maturity too so unlockBalances() refreshes
+       the cached withdrawable balance the moment this deposit matures. */
+    insertUnlockTransactionJob(depositOutput.transactionHash, static_cast<uint32_t>(deposit.unlockHeight), container);
+
+    return id;
   }
 
   DepositId WalletGreen::insertDeposit(
@@ -3803,7 +3852,7 @@ namespace cn
         {
           continue;
         }
-        auto id = insertNewDeposit(depositOutput, transactionId, m_currency, transactionInfo.blockHeight);
+        auto id = insertNewDeposit(depositOutput, transactionId, m_currency, transactionInfo.blockHeight, containerAmounts.container);
         updatedDepositIds.push_back(id);
       }
 

--- a/src/Wallet/WalletGreen.cpp
+++ b/src/Wallet/WalletGreen.cpp
@@ -8,8 +8,11 @@
 #include "WalletGreen.h"
 
 #include <algorithm>
+#include <chrono>
 #include <ctime>
 #include <cassert>
+#include <future>
+#include <memory>
 #include <numeric>
 #include <random>
 #include <set>
@@ -250,7 +253,14 @@ namespace cn
       doShutdown();
     }
 
-    m_dispatcher.yield(); //let remote spawns finish
+    try
+    {
+      waitForRemoteSpawns();
+    }
+    catch (const std::exception &e)
+    {
+      m_logger(WARNING, BRIGHT_YELLOW) << "Failed to drain remote spawns on destruction: " << e.what();
+    }
   }
 
   void WalletGreen::initialize(
@@ -681,7 +691,38 @@ namespace cn
     throwIfNotInitialized();
     doShutdown();
 
-    m_dispatcher.yield(); //let remote spawns finish
+    waitForRemoteSpawns();
+  }
+
+  /* Let remote spawns queued before shutdown finish, so none of them touches
+     this wallet after it is destroyed. yield() is only legal on the thread
+     that owns (pumps) the dispatcher; calling it from another thread — e.g.
+     the GUI thread in conceal-desktop closing the wallet while the node
+     thread pumps the same dispatcher — races the event loop and can hang or
+     corrupt state. From a foreign thread, queue a barrier through
+     remoteSpawn() (the only thread-safe dispatcher call) and wait for the
+     owner thread to execute it instead. */
+  void WalletGreen::waitForRemoteSpawns()
+  {
+    if (m_dispatcher.isOwnerThread())
+    {
+      m_dispatcher.yield();
+      return;
+    }
+
+    /* shared_ptr keeps the barrier alive even if the queued procedure runs
+       after a timeout below. */
+    auto barrier = std::make_shared<std::promise<void>>();
+    auto barrierReached = barrier->get_future();
+    m_dispatcher.remoteSpawn([barrier] { barrier->set_value(); });
+
+    /* Bounded wait: if the owner thread is no longer pumping the dispatcher,
+       a plain wait() would freeze the caller forever — the very hang this
+       path is meant to prevent. */
+    if (barrierReached.wait_for(std::chrono::seconds(10)) != std::future_status::ready)
+    {
+      m_logger(WARNING, BRIGHT_YELLOW) << "Timed out draining remote spawns; dispatcher is not being pumped";
+    }
   }
 
   void WalletGreen::initBlockchain(const crypto::PublicKey &viewPublicKey)

--- a/src/Wallet/WalletGreen.h
+++ b/src/Wallet/WalletGreen.h
@@ -118,7 +118,8 @@ public:
   DepositId insertDeposit(const Deposit &deposit, size_t depositIndexInTransaction, const crypto::Hash &transactionHash);
   DepositId insertNewDeposit(const TransactionOutputInformation &depositOutput,
                              TransactionId creatingTransactionId,
-                             const Currency &currency, uint32_t height);
+                             const Currency &currency, uint32_t height,
+                             cn::ITransfersContainer *container);
 
   std::vector<TransactionOutputInformation> getUnspentOutputs() override;
   size_t getUnspentOutputsCount() override;
@@ -245,6 +246,7 @@ protected:
 
   void updateBalance(cn::ITransfersContainer *container);
   void unlockBalances(uint32_t height);
+  void scheduleDepositUnlockJobs();
 
   const WalletRecord &getWalletRecord(const crypto::PublicKey &key) const;
   const WalletRecord &getWalletRecord(const std::string &address) const;

--- a/src/Wallet/WalletGreen.h
+++ b/src/Wallet/WalletGreen.h
@@ -141,6 +141,7 @@ protected:
   void throwIfStopped() const;
   void throwIfTrackingMode() const;
   void doShutdown();
+  void waitForRemoteSpawns();
   void clearCaches(bool clearTransactions, bool clearCachedData);
   void clearCacheAndShutdown();
   void convertAndLoadWalletFile(const std::string &path, std::ifstream &&walletFileStream);

--- a/tests/System/DispatcherTests.cpp
+++ b/tests/System/DispatcherTests.cpp
@@ -65,6 +65,25 @@ TEST_F(DispatcherTests, clearCalledFromSpawnRemainsDispatcherWorkable) {
   ASSERT_TRUE(spawn2Done);
 }
 
+TEST_F(DispatcherTests, isOwnerThreadDetectsForeignThread) {
+  ASSERT_TRUE(dispatcher.isOwnerThread());
+  bool foreignThreadIsOwner = true;
+  std::thread foreignThread([&]() { foreignThreadIsOwner = dispatcher.isOwnerThread(); });
+  foreignThread.join();
+  ASSERT_FALSE(foreignThreadIsOwner);
+}
+
+TEST_F(DispatcherTests, remoteSpawnFromForeignThreadRunsOnOwnerThread) {
+  bool procedureDone = false;
+  std::thread foreignThread([&]() {
+    dispatcher.remoteSpawn([&]() { procedureDone = true; });
+  });
+
+  foreignThread.join();
+  dispatcher.yield();
+  ASSERT_TRUE(procedureDone);
+}
+
 TEST_F(DispatcherTests, timerIsHandledOnlyAfterAllSpawnedTasksAreHandled) {
   Event event1(dispatcher);
   Event event2(dispatcher);


### PR DESCRIPTION
## Summary
- Align deposit unlock status with the wallet's own chain height so UI/RPC state matches withdrawability
- Schedule deposit-term unlock jobs (including on wallet load) so matured deposits refresh withdrawable balance
- Retry deposit/transfer selection when selected amounts lack available mixins; clarify MIXIN_COUNT_TOO_BIG
- Also included: safe WalletGreen shutdown drain from foreign threads (GUI close), plus agent/docs sync notes
